### PR TITLE
*: support env

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
     - run: which cargo && cargo version && clang --version && openssl version && which cmake && cmake --version
     - run: cargo xtask submodule
     - run: cargo clippy --all -- -D clippy::all
-    - run: cargo xtask format && git diff-index --quiet HEAD
+    - run: cargo xtask format && git diff --exit-code HEAD
 
   Linux-Stable:
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,7 +73,7 @@ jobs:
     - run: rustup default nightly
     - run: which cargo && cargo version && clang --version && openssl version
     - run: cargo xtask submodule
-    - run: RUSTFLAGS="-Z sanitizer=address" cargo test --features encryption --all --target x86_64-unknown-linux-gnu
+    - run: RUSTFLAGS="-Z sanitizer=address" cargo test --features encryption,nightly --all --target x86_64-unknown-linux-gnu
 
   Mac:
     name: Mac

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@ Cargo.lock
 **/*.rs.bk
 
 .vscode
+
+.idea

--- a/tirocks-sys/bindings/bindings.rs
+++ b/tirocks-sys/bindings/bindings.rs
@@ -103,6 +103,15 @@ pub enum rocksdb_InfoLogLevel {
 }
 #[repr(i32)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum rocksdb_encryption_EncryptionMethod {
+    kUnknown = 0,
+    kPlaintext = 1,
+    kAES128_CTR = 2,
+    kAES192_CTR = 3,
+    kAES256_CTR = 4,
+}
+#[repr(i32)]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub enum rocksdb_TableFileCreationReason {
     kFlush = 0,
     kCompaction = 1,
@@ -1118,6 +1127,16 @@ pub enum crocksdb_table_property_t {
     kPrefixExtractorName = 15,
     kPropertyCollectorsNames = 16,
     kCompressionName = 17,
+}
+#[repr(C)]
+#[derive(Debug)]
+pub struct crocksdb_file_encryption_info_t {
+    _unused: [u8; 0],
+}
+#[repr(C)]
+#[derive(Debug)]
+pub struct crocksdb_encryption_key_manager_t {
+    _unused: [u8; 0],
 }
 #[repr(C)]
 #[derive(Debug)]
@@ -3911,6 +3930,130 @@ extern "C" {
 }
 extern "C" {
     pub fn crocksdb_sequential_file_destroy(arg1: *mut crocksdb_sequential_file_t);
+}
+extern "C" {
+    pub fn crocksdb_file_encryption_info_create() -> *mut crocksdb_file_encryption_info_t;
+}
+extern "C" {
+    pub fn crocksdb_file_encryption_info_destroy(file_info: *mut crocksdb_file_encryption_info_t);
+}
+extern "C" {
+    pub fn crocksdb_file_encryption_info_method(
+        file_info: *mut crocksdb_file_encryption_info_t,
+    ) -> rocksdb_encryption_EncryptionMethod;
+}
+extern "C" {
+    pub fn crocksdb_file_encryption_info_key(
+        file_info: *mut crocksdb_file_encryption_info_t,
+        keylen: *mut usize,
+    ) -> *const libc::c_char;
+}
+extern "C" {
+    pub fn crocksdb_file_encryption_info_iv(
+        file_info: *mut crocksdb_file_encryption_info_t,
+        ivlen: *mut usize,
+    ) -> *const libc::c_char;
+}
+extern "C" {
+    pub fn crocksdb_file_encryption_info_set_method(
+        file_info: *mut crocksdb_file_encryption_info_t,
+        method: rocksdb_encryption_EncryptionMethod,
+    );
+}
+extern "C" {
+    pub fn crocksdb_file_encryption_info_set_key(
+        file_info: *mut crocksdb_file_encryption_info_t,
+        key: *const libc::c_char,
+        keylen: usize,
+    );
+}
+extern "C" {
+    pub fn crocksdb_file_encryption_info_set_iv(
+        file_info: *mut crocksdb_file_encryption_info_t,
+        iv: *const libc::c_char,
+        ivlen: usize,
+    );
+}
+pub type crocksdb_encryption_key_manager_get_file_cb = ::std::option::Option<
+    unsafe extern "C" fn(
+        state: *mut libc::c_void,
+        fname: *const libc::c_char,
+        file_info: *mut crocksdb_file_encryption_info_t,
+        arg1: *mut rocksdb_Status,
+    ),
+>;
+pub type crocksdb_encryption_key_manager_new_file_cb = ::std::option::Option<
+    unsafe extern "C" fn(
+        state: *mut libc::c_void,
+        fname: *const libc::c_char,
+        file_info: *mut crocksdb_file_encryption_info_t,
+        arg1: *mut rocksdb_Status,
+    ),
+>;
+pub type crocksdb_encryption_key_manager_delete_file_cb = ::std::option::Option<
+    unsafe extern "C" fn(
+        state: *mut libc::c_void,
+        fname: *const libc::c_char,
+        arg1: *mut rocksdb_Status,
+    ),
+>;
+pub type crocksdb_encryption_key_manager_link_file_cb = ::std::option::Option<
+    unsafe extern "C" fn(
+        state: *mut libc::c_void,
+        src_fname: *const libc::c_char,
+        dst_fname: *const libc::c_char,
+        arg1: *mut rocksdb_Status,
+    ),
+>;
+extern "C" {
+    pub fn crocksdb_encryption_key_manager_create(
+        state: *mut libc::c_void,
+        destructor: ::std::option::Option<unsafe extern "C" fn(arg1: *mut libc::c_void)>,
+        get_file: crocksdb_encryption_key_manager_get_file_cb,
+        new_file: crocksdb_encryption_key_manager_new_file_cb,
+        delete_file: crocksdb_encryption_key_manager_delete_file_cb,
+        link_file: crocksdb_encryption_key_manager_link_file_cb,
+    ) -> *mut crocksdb_encryption_key_manager_t;
+}
+extern "C" {
+    pub fn crocksdb_encryption_key_manager_destroy(arg1: *mut crocksdb_encryption_key_manager_t);
+}
+extern "C" {
+    pub fn crocksdb_encryption_key_manager_get_file(
+        key_manager: *mut crocksdb_encryption_key_manager_t,
+        fname: *const libc::c_char,
+        file_info: *mut crocksdb_file_encryption_info_t,
+        arg1: *mut rocksdb_Status,
+    );
+}
+extern "C" {
+    pub fn crocksdb_encryption_key_manager_new_file(
+        key_manager: *mut crocksdb_encryption_key_manager_t,
+        fname: *const libc::c_char,
+        file_info: *mut crocksdb_file_encryption_info_t,
+        arg1: *mut rocksdb_Status,
+    );
+}
+extern "C" {
+    pub fn crocksdb_encryption_key_manager_delete_file(
+        key_manager: *mut crocksdb_encryption_key_manager_t,
+        fname: *const libc::c_char,
+        arg1: *mut rocksdb_Status,
+    );
+}
+extern "C" {
+    pub fn crocksdb_encryption_key_manager_link_file(
+        key_manager: *mut crocksdb_encryption_key_manager_t,
+        src_fname: *const libc::c_char,
+        dst_fname: *const libc::c_char,
+        arg1: *mut rocksdb_Status,
+    );
+}
+extern "C" {
+    pub fn crocksdb_key_managed_encrypted_env_create(
+        arg1: *mut rocksdb_Env,
+        arg2: *mut crocksdb_encryption_key_manager_t,
+    ) -> *mut rocksdb_Env;
 }
 pub type crocksdb_file_system_inspector_read_cb = ::std::option::Option<
     unsafe extern "C" fn(state: *mut libc::c_void, len: usize, s: *mut rocksdb_Status) -> usize,

--- a/tirocks-sys/bindings/bindings.rs
+++ b/tirocks-sys/bindings/bindings.rs
@@ -58,6 +58,31 @@ pub enum rocksdb_Status_Severity {
     kUnrecoverableError = 4,
     kMaxSeverity = 5,
 }
+#[repr(C)]
+#[repr(align(8))]
+#[derive(Debug, Copy, Clone)]
+pub struct rocksdb_Env {
+    pub _bindgen_opaque_blob: [u64; 2usize],
+}
+#[repr(u32)]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum rocksdb_Env_WriteLifeTimeHint {
+    WLTH_NOT_SET = 0,
+    WLTH_NONE = 1,
+    WLTH_SHORT = 2,
+    WLTH_MEDIUM = 3,
+    WLTH_LONG = 4,
+    WLTH_EXTREME = 5,
+}
+#[repr(u32)]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum rocksdb_Env_Priority {
+    BOTTOM = 0,
+    LOW = 1,
+    HIGH = 2,
+    USER = 3,
+    TOTAL = 4,
+}
 #[repr(u32)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub enum rocksdb_Env_IOPriority {
@@ -497,6 +522,12 @@ pub enum rocksdb_PerfLevel {
 }
 #[repr(i32)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum rocksdb_RateLimiter_OpType {
+    kRead = 0,
+    kWrite = 1,
+}
+#[repr(i32)]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub enum rocksdb_RateLimiter_Mode {
     kReadsOnly = 0,
     kWritesOnly = 1,
@@ -626,11 +657,6 @@ pub struct crocksdb_compactionfilterfactory_t {
 #[repr(C)]
 #[derive(Debug)]
 pub struct crocksdb_comparator_t {
-    _unused: [u8; 0],
-}
-#[repr(C)]
-#[derive(Debug)]
-pub struct crocksdb_env_t {
     _unused: [u8; 0],
 }
 #[repr(C)]
@@ -2442,7 +2468,7 @@ pub type crocksdb_logger_logv_cb = ::std::option::Option<
     unsafe extern "C" fn(
         arg1: *mut libc::c_void,
         log_level: rocksdb_InfoLogLevel,
-        arg2: *const libc::c_char,
+        msg: rocksdb_Slice,
     ),
 >;
 extern "C" {
@@ -2627,7 +2653,7 @@ extern "C" {
     pub fn crocksdb_options_set_paranoid_checks(arg1: *mut crocksdb_options_t, arg2: libc::c_uchar);
 }
 extern "C" {
-    pub fn crocksdb_options_set_env(arg1: *mut crocksdb_options_t, arg2: *mut crocksdb_env_t);
+    pub fn crocksdb_options_set_env(arg1: *mut crocksdb_options_t, arg2: *mut rocksdb_Env);
 }
 extern "C" {
     pub fn crocksdb_logger_create(
@@ -2816,7 +2842,7 @@ extern "C" {
 extern "C" {
     pub fn crocksdb_load_latest_options(
         dbpath: *const libc::c_char,
-        env: *mut crocksdb_env_t,
+        env: *mut rocksdb_Env,
         db_options: *mut crocksdb_options_t,
         cf_descs: *mut *mut *mut crocksdb_column_family_descriptor,
         cf_descs_len: *mut usize,
@@ -3379,6 +3405,7 @@ extern "C" {
         limiter: *mut crocksdb_ratelimiter_t,
         bytes: i64,
         pri: rocksdb_Env_IOPriority,
+        op_ty: rocksdb_RateLimiter_OpType,
     );
 }
 extern "C" {
@@ -3814,46 +3841,44 @@ extern "C" {
     pub fn crocksdb_cache_set_capacity(cache: *mut crocksdb_cache_t, capacity: usize);
 }
 extern "C" {
-    pub fn crocksdb_default_env_create() -> *mut crocksdb_env_t;
+    pub fn crocksdb_default_env_create() -> *mut rocksdb_Env;
 }
 extern "C" {
-    pub fn crocksdb_mem_env_create() -> *mut crocksdb_env_t;
+    pub fn crocksdb_mem_env_create(arg1: *mut rocksdb_Env) -> *mut rocksdb_Env;
 }
 extern "C" {
     pub fn crocksdb_ctr_encrypted_env_create(
-        base_env: *mut crocksdb_env_t,
+        base_env: *mut rocksdb_Env,
         ciphertext: *const libc::c_char,
         ciphertext_len: usize,
-    ) -> *mut crocksdb_env_t;
+    ) -> *mut rocksdb_Env;
 }
 extern "C" {
-    pub fn crocksdb_env_set_background_threads(env: *mut crocksdb_env_t, n: libc::c_int);
-}
-extern "C" {
-    pub fn crocksdb_env_set_high_priority_background_threads(
-        env: *mut crocksdb_env_t,
+    pub fn crocksdb_env_set_background_threads(
+        env: *mut rocksdb_Env,
         n: libc::c_int,
+        pri: rocksdb_Env_Priority,
     );
 }
 extern "C" {
-    pub fn crocksdb_env_join_all_threads(env: *mut crocksdb_env_t);
+    pub fn crocksdb_env_join_all_threads(env: *mut rocksdb_Env);
 }
 extern "C" {
     pub fn crocksdb_env_file_exists(
-        env: *mut crocksdb_env_t,
-        path: *const libc::c_char,
+        env: *mut rocksdb_Env,
+        path: rocksdb_Slice,
         s: *mut rocksdb_Status,
     );
 }
 extern "C" {
     pub fn crocksdb_env_delete_file(
-        env: *mut crocksdb_env_t,
-        path: *const libc::c_char,
+        env: *mut rocksdb_Env,
+        path: rocksdb_Slice,
         s: *mut rocksdb_Status,
     );
 }
 extern "C" {
-    pub fn crocksdb_env_destroy(arg1: *mut crocksdb_env_t);
+    pub fn crocksdb_env_destroy(arg1: *mut rocksdb_Env);
 }
 extern "C" {
     pub fn crocksdb_envoptions_create() -> *mut crocksdb_envoptions_t;
@@ -3863,8 +3888,8 @@ extern "C" {
 }
 extern "C" {
     pub fn crocksdb_sequential_file_create(
-        env: *mut crocksdb_env_t,
-        path: *const libc::c_char,
+        env: *mut rocksdb_Env,
+        path: rocksdb_Slice,
         opts: *const crocksdb_envoptions_t,
         s: *mut rocksdb_Status,
     ) -> *mut crocksdb_sequential_file_t;
@@ -3920,9 +3945,9 @@ extern "C" {
 }
 extern "C" {
     pub fn crocksdb_file_system_inspected_env_create(
-        arg1: *mut crocksdb_env_t,
+        arg1: *mut rocksdb_Env,
         arg2: *mut crocksdb_file_system_inspector_t,
-    ) -> *mut crocksdb_env_t;
+    ) -> *mut rocksdb_Env;
 }
 extern "C" {
     pub fn crocksdb_sstfilereader_create(
@@ -4333,7 +4358,7 @@ extern "C" {
 extern "C" {
     pub fn crocksdb_create_env_logger(
         fname: *const libc::c_char,
-        env: *mut crocksdb_env_t,
+        env: *mut rocksdb_Env,
     ) -> *mut crocksdb_logger_t;
 }
 extern "C" {

--- a/tirocks-sys/build.rs
+++ b/tirocks-sys/build.rs
@@ -41,8 +41,10 @@ fn bindgen_rocksdb(file_path: &Path) {
         .allowlist_type(r"\brocksdb::Histograms")
         .allowlist_type(r"\brocksdb::titandb::TickerType")
         .allowlist_type(r"\brocksdb::titandb::HistogramType")
+        .opaque_type(r"\brocksdb::Env")
         // Block all system headers
         .blocklist_file(r"^/.*")
+        .blocklist_type(r"\brocksdb::Env_FileAttributes")
         .with_codegen_config(
             bindgen::CodegenConfig::FUNCTIONS
                 | bindgen::CodegenConfig::VARS

--- a/tirocks-sys/build.rs
+++ b/tirocks-sys/build.rs
@@ -22,7 +22,6 @@ fn bindgen_rocksdb(file_path: &Path) {
     if env::var("CARGO_CFG_TARGET_OS").map_or(false, |s| s == "windows") {
         builder = builder.clang_arg("-D _WIN32_WINNT=0x600");
     }
-    // TODO: generate bindings of encryption
     let builder = builder
         .header("crocksdb/crocksdb/c.h")
         .header("rocksdb/include/rocksdb/statistics.h")
@@ -31,6 +30,7 @@ fn bindgen_rocksdb(file_path: &Path) {
         .clang_arg("-Irocksdb/include")
         .clang_arg("-Ititan/include")
         .clang_arg("-std=c++11")
+        .clang_arg("-DOPENSSL")
         .rustfmt_bindings(true)
         .allowlist_function(r"\bcrocksdb_.*")
         .allowlist_type(r"\bcrocksdb_.*")

--- a/tirocks-sys/crocksdb/c.cc
+++ b/tirocks-sys/crocksdb/c.cc
@@ -4173,7 +4173,7 @@ void crocksdb_encryption_key_manager_link_file(
 
 Env* crocksdb_key_managed_encrypted_env_create(
     Env* base_env, crocksdb_encryption_key_manager_t* key_manager) {
-  return NewKeyManagedEncryptedEnv(base_env->rep, key_manager->rep);
+  return NewKeyManagedEncryptedEnv(base_env, key_manager->rep);
 }
 #endif
 

--- a/tirocks-sys/src/lib.rs
+++ b/tirocks-sys/src/lib.rs
@@ -144,48 +144,11 @@ impl Drop for rocksdb_Status {
     }
 }
 
-/// A helper micros for handling FFI calls that need error handling.
-///
-/// It's simply translate the call
-/// ```ignored
-/// ffi_call!(func(...))
-/// ```
-/// to
-/// ```ignored
-/// let res = tirocks_sys::func(..., &mut status);
-/// if status.ok() {
-///     Ok(res)
-/// } else {
-///     Err(status)
-/// }
-/// ```
-#[macro_export]
-macro_rules! ffi_call {
-    ($func:ident($($arg:expr),+)) => ({
-        let mut status = $crate::rocksdb_Status::with_code($crate::rocksdb_Status_Code::kOk);
-        let res = $crate::$func($($arg),+, &mut status);
-        if status.ok() {
-            Ok(res)
-        } else {
-            Err(status)
-        }
-    });
-    ($func:ident()) => ({
-        let mut status = $crate::rocksdb_Status::with_code($crate::rocksdb_Status_Code::kOk);
-        let res = $crate::$func(&mut status);
-        if status.ok() {
-            Ok(res)
-        } else {
-            Err(status)
-        }
-    })
-}
-
 #[cfg(test)]
 mod tests {
     use crate::{
-        crocksdb_close, crocksdb_options_create, crocksdb_options_destroy,
-        crocksdb_options_set_create_if_missing, r, rocksdb_Status_Code,
+        crocksdb_close, crocksdb_open, crocksdb_options_create, crocksdb_options_destroy,
+        crocksdb_options_set_create_if_missing, r, rocksdb_Status, rocksdb_Status_Code,
     };
 
     use super::s;
@@ -204,17 +167,18 @@ mod tests {
         unsafe {
             let opt = crocksdb_options_create();
             crocksdb_options_set_create_if_missing(opt, 0);
-            let s = ffi_call!(crocksdb_open(opt, r(path.as_bytes())));
-            let e = s.unwrap_err();
-            assert!(!e.ok());
-            assert_eq!(e.code_, rocksdb_Status_Code::kInvalidArgument);
-            let msg = e.message().unwrap().unwrap();
+            let mut status = rocksdb_Status::with_code(rocksdb_Status_Code::kOk);
+            let s = crocksdb_open(opt, r(path.as_bytes()), &mut status);
+            assert!(!status.ok());
+            assert!(s.is_null());
+            assert_eq!(status.code(), rocksdb_Status_Code::kInvalidArgument);
+            let msg = status.message().unwrap().unwrap();
             assert!(msg.contains("does not exist"), "{}", msg);
 
             crocksdb_options_set_create_if_missing(opt, 1);
-            let s = ffi_call!(crocksdb_open(opt, r(path.as_bytes())));
-            let e = s.unwrap();
-            crocksdb_close(e);
+            let s = crocksdb_open(opt, r(path.as_bytes()), &mut status);
+            assert!(status.ok(), "{:?}", status.message());
+            crocksdb_close(s);
             crocksdb_options_destroy(opt);
         }
     }

--- a/tirocks/Cargo.toml
+++ b/tirocks/Cargo.toml
@@ -2,5 +2,16 @@
 name = "tirocks"
 version = "0.1.0"
 edition = "2021"
+authors = ["The TiKV Project Developers"]
+license = "Apache-2.0"
+keywords = ["rocksdb", "bindings"]
+
+[features]
+nightly = []
 
 [dependencies]
+libc = "0.2.11"
+tirocks-sys = { path = "../tirocks-sys" }
+
+[dev-dependencies]
+tempfile = "3.0"

--- a/tirocks/src/env.rs
+++ b/tirocks/src/env.rs
@@ -1,0 +1,201 @@
+// Copyright 2022 TiKV Project Authors. Licensed under Apache-2.0.
+
+mod inspected;
+pub mod logger;
+mod sequential_file;
+
+use self::inspected::DBFileSystemInspector;
+use crate::{Code, Result, Status};
+use libc::c_char;
+use tirocks_sys::{ffi_try, r};
+
+pub use self::inspected::FileSystemInspector;
+pub use self::sequential_file::SequentialFile;
+
+pub type IoPriority = tirocks_sys::rocksdb_Env_IOPriority;
+pub type Priority = tirocks_sys::rocksdb_Env_Priority;
+
+/// Options while opening a file to read/write
+// TODO: perhaps use the C struct directly
+pub struct EnvOptions {
+    ptr: *mut tirocks_sys::crocksdb_envoptions_t,
+}
+
+impl Default for EnvOptions {
+    #[inline]
+    fn default() -> EnvOptions {
+        unsafe {
+            EnvOptions {
+                ptr: tirocks_sys::crocksdb_envoptions_create(),
+            }
+        }
+    }
+}
+
+impl Drop for EnvOptions {
+    fn drop(&mut self) {
+        unsafe {
+            tirocks_sys::crocksdb_envoptions_destroy(self.ptr);
+        }
+    }
+}
+
+/// An Env is an interface used by the rocksdb implementation to access
+/// operating system functionality like the filesystem etc.  Callers
+/// may wish to provide a custom Env object when opening a database to
+/// get fine gain control; e.g., to rate limit file system operations.
+pub struct Env {
+    ptr: *mut tirocks_sys::rocksdb_Env,
+    // Some env is based on other instance. And base should outlive `ptr`.
+    _base: Option<Box<Env>>,
+}
+
+unsafe impl Send for Env {}
+
+unsafe impl Sync for Env {}
+
+impl Default for Env {
+    /// Return a default environment suitable for the current operating
+    /// system.  Sophisticated users may wish to provide their own Env
+    /// implementation instead of relying on this default environment.
+    #[inline]
+    fn default() -> Env {
+        unsafe { Env::new(None, tirocks_sys::crocksdb_default_env_create()) }
+    }
+}
+
+impl Env {
+    fn new(base: Option<Env>, ptr: *mut tirocks_sys::rocksdb_Env) -> Env {
+        Env {
+            ptr,
+            _base: base.map(Box::new),
+        }
+    }
+
+    /// Returns a new environment that stores its data in memory and delegates
+    /// all non-file-storage tasks to base_env. base_env must remain live
+    /// while the result is in use.
+    #[inline]
+    pub fn with_mem(base: Env) -> Env {
+        unsafe {
+            let mem = tirocks_sys::crocksdb_mem_env_create(base.ptr);
+            Env::new(Some(base), mem)
+        }
+    }
+
+    /// Create a ctr encrypted env with a given base env and a given ciper text.
+    /// The length of ciper text must be 2^n, and must be less or equal to 2048.
+    /// The recommanded block size are 1024, 512 and 256.
+    pub fn with_ctr_encrypted(base_env: Env, ciphertext: &[u8]) -> Result<Env> {
+        let len = ciphertext.len();
+        if len > 2048 || !len.is_power_of_two() {
+            return Err(Status::with_error(
+                Code::kInvalidArgument,
+                "ciphertext length must be less or equal to 2048, and must be power of 2",
+            ));
+        }
+        let env = unsafe {
+            tirocks_sys::crocksdb_ctr_encrypted_env_create(
+                base_env.ptr,
+                ciphertext.as_ptr() as *const c_char,
+                len,
+            )
+        };
+        Ok(Env::new(Some(base_env), env))
+    }
+
+    /// Create an encrypted env that accepts an external key manager.
+    #[cfg(feature = "encryption")]
+    pub fn with_key_managed_encrypted<T: EncryptionKeyManager>(
+        base_env: Env,
+        key_manager: T,
+    ) -> Result<Env, String> {
+        let db_key_manager = DBEncryptionKeyManager::new(key_manager);
+        let env = unsafe {
+            crocksdb_ffi::crocksdb_key_managed_encrypted_env_create(
+                base_env.inner,
+                db_key_manager.inner,
+            )
+        };
+        Ok(Env::new(Some(base_env), env))
+    }
+
+    pub fn with_file_system_inspected<T: FileSystemInspector>(
+        base_env: Env,
+        file_system_inspector: T,
+    ) -> Result<Env> {
+        let db_file_system_inspector = DBFileSystemInspector::new(file_system_inspector);
+        let env = unsafe {
+            tirocks_sys::crocksdb_file_system_inspected_env_create(
+                base_env.ptr,
+                db_file_system_inspector.ptr,
+            )
+        };
+        Ok(Env::new(Some(base_env), env))
+    }
+
+    /// Create a brand new sequentially-readable file with the specified name.
+    /// On failure returns non-OK.  If the file does not exist, returns a non-OK status.
+    #[inline]
+    pub fn new_sequential_file(&self, path: &str, opts: EnvOptions) -> Result<SequentialFile> {
+        unsafe {
+            let file_path = r(path.as_bytes());
+            let file = ffi_try!(crocksdb_sequential_file_create(
+                self.ptr, file_path, opts.ptr
+            ));
+            Ok(SequentialFile::from_ptr(file))
+        }
+    }
+
+    /// Returns OK if the named file exists.
+    ///         NotFound if the named file does not exist,
+    ///                  the calling process does not have permission to determine
+    ///                  whether this file exists, or if the path is invalid.
+    ///         IOError if an IO Error was encountered
+    #[inline]
+    pub fn file_exists(&self, path: &str) -> Result<()> {
+        unsafe {
+            let file_path = r(path.as_bytes());
+            ffi_try!(crocksdb_env_file_exists(self.ptr, file_path));
+            Ok(())
+        }
+    }
+
+    /// Delete the named file.
+    #[inline]
+    pub fn delete_file(&self, path: &str) -> Result<()> {
+        unsafe {
+            let file_path = r(path.as_bytes());
+            ffi_try!(crocksdb_env_delete_file(self.ptr, file_path));
+            Ok(())
+        }
+    }
+
+    /// The number of background worker threads of a specific thread pool
+    /// for this environment. 'LOW' is the default pool.
+    #[inline]
+    pub fn set_background_threads(&self, pri: Priority, number: usize) {
+        unsafe {
+            tirocks_sys::crocksdb_env_set_background_threads(self.ptr, number as i32, pri);
+        }
+    }
+
+    /// Wait for all threads to terminate.
+    #[inline]
+    pub fn wait_for_join(&self) {
+        unsafe {
+            tirocks_sys::crocksdb_env_join_all_threads(self.ptr);
+        }
+    }
+}
+
+impl Drop for Env {
+    fn drop(&mut self) {
+        unsafe {
+            tirocks_sys::crocksdb_env_destroy(self.ptr);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/tirocks/src/env.rs
+++ b/tirocks/src/env.rs
@@ -7,7 +7,7 @@ mod sequential_file;
 use self::inspected::DBFileSystemInspector;
 use crate::{Code, Result, Status};
 use libc::c_char;
-use tirocks_sys::{ffi_try, r};
+use tirocks_sys::{ffi_call, r};
 
 pub use self::inspected::FileSystemInspector;
 pub use self::sequential_file::SequentialFile;
@@ -140,9 +140,9 @@ impl Env {
     pub fn new_sequential_file(&self, path: &str, opts: EnvOptions) -> Result<SequentialFile> {
         unsafe {
             let file_path = r(path.as_bytes());
-            let file = ffi_try!(crocksdb_sequential_file_create(
+            let file = ffi_call!(crocksdb_sequential_file_create(
                 self.ptr, file_path, opts.ptr
-            ));
+            ))?;
             Ok(SequentialFile::from_ptr(file))
         }
     }
@@ -156,7 +156,7 @@ impl Env {
     pub fn file_exists(&self, path: &str) -> Result<()> {
         unsafe {
             let file_path = r(path.as_bytes());
-            ffi_try!(crocksdb_env_file_exists(self.ptr, file_path));
+            ffi_call!(crocksdb_env_file_exists(self.ptr, file_path))?;
             Ok(())
         }
     }
@@ -166,7 +166,7 @@ impl Env {
     pub fn delete_file(&self, path: &str) -> Result<()> {
         unsafe {
             let file_path = r(path.as_bytes());
-            ffi_try!(crocksdb_env_delete_file(self.ptr, file_path));
+            ffi_call!(crocksdb_env_delete_file(self.ptr, file_path))?;
             Ok(())
         }
     }

--- a/tirocks/src/env.rs
+++ b/tirocks/src/env.rs
@@ -107,7 +107,7 @@ impl Env {
 
     /// Create an encrypted env that accepts an external key manager.
     #[cfg(feature = "encryption")]
-    pub fn with_encrypted<T: KeyManager>(
+    pub fn with_key_manager_encrypted<T: KeyManager>(
         base_env: Env,
         key_manager: T,
     ) -> Result<Env, String> {

--- a/tirocks/src/env/inspected.rs
+++ b/tirocks/src/env/inspected.rs
@@ -1,0 +1,111 @@
+// Copyright 2022 TiKV Project Authors. Licensed under Apache-2.0.
+
+use crate::Result;
+use libc::c_void;
+use tirocks_sys::rocksdb_Status;
+
+/// Trait to inspect storage requests. FileSystemInspectedEnv will consult
+/// FileSystemInspector before issuing actual disk IO.
+pub trait FileSystemInspector {
+    /// Request to read `len` bytes and return the allowed size.
+    #[inline]
+    fn read(&self, len: usize) -> Result<usize> {
+        Ok(len)
+    }
+
+    /// Request to write `len` bytes and return the allowed size.
+    #[inline]
+    fn write(&self, len: usize) -> Result<usize> {
+        Ok(len)
+    }
+}
+
+extern "C" fn file_system_inspector_destructor<T: FileSystemInspector>(ctx: *mut c_void) {
+    unsafe {
+        // Recover from raw pointer and implicitly drop.
+        Box::from_raw(ctx as *mut T);
+    }
+}
+
+extern "C" fn file_system_inspector_read<T: FileSystemInspector>(
+    ctx: *mut c_void,
+    len: usize,
+    status: *mut rocksdb_Status,
+) -> usize {
+    let file_system_inspector = unsafe { &*(ctx as *mut T) };
+    match file_system_inspector.read(len) {
+        Ok(ret) => ret,
+        Err(e) => {
+            unsafe {
+                std::ptr::write(status, e.into_raw());
+            }
+            0
+        }
+    }
+}
+
+extern "C" fn file_system_inspector_write<T: FileSystemInspector>(
+    ctx: *mut c_void,
+    len: usize,
+    status: *mut rocksdb_Status,
+) -> usize {
+    let file_system_inspector = unsafe { &*(ctx as *mut T) };
+    match file_system_inspector.write(len) {
+        Ok(ret) => ret,
+        Err(e) => {
+            unsafe {
+                std::ptr::write(status, e.into_raw());
+            }
+            0
+        }
+    }
+}
+
+pub(crate) struct DBFileSystemInspector {
+    pub ptr: *mut tirocks_sys::crocksdb_file_system_inspector_t,
+}
+
+unsafe impl Send for DBFileSystemInspector {}
+unsafe impl Sync for DBFileSystemInspector {}
+
+impl DBFileSystemInspector {
+    #[inline]
+    pub fn new<T: FileSystemInspector>(file_system_inspector: T) -> DBFileSystemInspector {
+        let ctx = Box::into_raw(Box::new(file_system_inspector)) as *mut c_void;
+        let instance = unsafe {
+            tirocks_sys::crocksdb_file_system_inspector_create(
+                ctx,
+                Some(file_system_inspector_destructor::<T>),
+                Some(file_system_inspector_read::<T>),
+                Some(file_system_inspector_write::<T>),
+            )
+        };
+        DBFileSystemInspector { ptr: instance }
+    }
+}
+
+impl Drop for DBFileSystemInspector {
+    #[inline]
+    fn drop(&mut self) {
+        unsafe {
+            tirocks_sys::crocksdb_file_system_inspector_destroy(self.ptr);
+        }
+    }
+}
+
+#[cfg(test)]
+impl FileSystemInspector for DBFileSystemInspector {
+    #[inline]
+    fn read(&self, len: usize) -> Result<usize> {
+        let ret =
+            unsafe { tirocks_sys::ffi_try!(crocksdb_file_system_inspector_read(self.ptr, len)) };
+        Ok(ret)
+    }
+
+    #[inline]
+    fn write(&self, len: usize) -> Result<usize> {
+        let ret =
+            unsafe { tirocks_sys::ffi_try!(crocksdb_file_system_inspector_write(self.ptr, len)) };
+        Ok(ret)
+    }
+}

--- a/tirocks/src/env/inspected.rs
+++ b/tirocks/src/env/inspected.rs
@@ -98,14 +98,14 @@ impl FileSystemInspector for DBFileSystemInspector {
     #[inline]
     fn read(&self, len: usize) -> Result<usize> {
         let ret =
-            unsafe { tirocks_sys::ffi_try!(crocksdb_file_system_inspector_read(self.ptr, len)) };
+            unsafe { tirocks_sys::ffi_call!(crocksdb_file_system_inspector_read(self.ptr, len))? };
         Ok(ret)
     }
 
     #[inline]
     fn write(&self, len: usize) -> Result<usize> {
         let ret =
-            unsafe { tirocks_sys::ffi_try!(crocksdb_file_system_inspector_write(self.ptr, len)) };
+            unsafe { tirocks_sys::ffi_call!(crocksdb_file_system_inspector_write(self.ptr, len))? };
         Ok(ret)
     }
 }

--- a/tirocks/src/env/logger.rs
+++ b/tirocks/src/env/logger.rs
@@ -1,0 +1,37 @@
+// Copyright 2022 TiKV Project Authors. Licensed under Apache-2.0.
+
+use libc::c_void;
+use tirocks_sys::{rocksdb_Slice, s};
+
+pub type LogLevel = tirocks_sys::rocksdb_InfoLogLevel;
+
+/// An interface for writing log messages.
+pub trait Logger: Send + Sync {
+    /// Write an entry to the log file with the specified log level.
+    fn logv(&self, log_level: LogLevel, data: &[u8]);
+}
+
+extern "C" fn destructor<L: Logger>(ctx: *mut c_void) {
+    unsafe {
+        Box::from_raw(ctx as *mut L);
+    }
+}
+
+extern "C" fn logv<L: Logger>(ctx: *mut c_void, log_level: LogLevel, log: rocksdb_Slice) {
+    unsafe {
+        let logger = &*(ctx as *mut L);
+        logger.logv(log_level, s(log));
+    }
+}
+
+#[allow(unused)]
+pub(crate) fn new_logger<L: Logger>(l: L) -> *mut tirocks_sys::crocksdb_logger_t {
+    unsafe {
+        let p = Box::new(l);
+        tirocks_sys::crocksdb_logger_create(
+            Box::into_raw(p) as *mut c_void,
+            Some(destructor::<L>),
+            Some(logv::<L>),
+        )
+    }
+}

--- a/tirocks/src/env/sequential_file.rs
+++ b/tirocks/src/env/sequential_file.rs
@@ -3,7 +3,7 @@
 use std::io::{self, Read};
 
 use crate::Result;
-use tirocks_sys::{crocksdb_sequential_file_t, ffi_try};
+use tirocks_sys::{crocksdb_sequential_file_t, ffi_call};
 
 /// A file abstraction for reading sequentially through a file.
 pub struct SequentialFile {
@@ -24,7 +24,7 @@ impl SequentialFile {
     #[inline]
     pub fn skip(&mut self, n: usize) -> Result<()> {
         unsafe {
-            ffi_try!(crocksdb_sequential_file_skip(self.ptr, n));
+            ffi_call!(crocksdb_sequential_file_skip(self.ptr, n))?;
             Ok(())
         }
     }
@@ -32,14 +32,14 @@ impl SequentialFile {
     #[inline]
     fn read(&mut self, buf: &mut [u8]) -> Result<usize> {
         unsafe {
-            let size = ffi_try! {
+            let size = ffi_call! {
                 crocksdb_sequential_file_read(
                     self.ptr,
                     buf.len(),
                     buf.as_mut_ptr() as *mut libc::c_char
                 )
-            };
-            Ok(size as usize)
+            }?;
+            Ok(size)
         }
     }
 }

--- a/tirocks/src/env/sequential_file.rs
+++ b/tirocks/src/env/sequential_file.rs
@@ -2,8 +2,8 @@
 
 use std::io::{self, Read};
 
-use crate::Result;
-use tirocks_sys::{crocksdb_sequential_file_t, ffi_call};
+use crate::{error::ffi_call, Result};
+use tirocks_sys::crocksdb_sequential_file_t;
 
 /// A file abstraction for reading sequentially through a file.
 pub struct SequentialFile {
@@ -23,23 +23,19 @@ impl SequentialFile {
     /// file, and Skip will return OK.
     #[inline]
     pub fn skip(&mut self, n: usize) -> Result<()> {
-        unsafe {
-            ffi_call!(crocksdb_sequential_file_skip(self.ptr, n))?;
-            Ok(())
-        }
+        unsafe { ffi_call!(crocksdb_sequential_file_skip(self.ptr, n)) }
     }
 
     #[inline]
     fn read(&mut self, buf: &mut [u8]) -> Result<usize> {
         unsafe {
-            let size = ffi_call! {
+            ffi_call! {
                 crocksdb_sequential_file_read(
                     self.ptr,
                     buf.len(),
                     buf.as_mut_ptr() as *mut libc::c_char
                 )
-            }?;
-            Ok(size)
+            }
         }
     }
 }

--- a/tirocks/src/env/sequential_file.rs
+++ b/tirocks/src/env/sequential_file.rs
@@ -50,3 +50,12 @@ impl Read for SequentialFile {
         Ok(SequentialFile::read(self, buf)?)
     }
 }
+
+impl Drop for SequentialFile {
+    #[inline]
+    fn drop(&mut self) {
+        unsafe {
+            tirocks_sys::crocksdb_sequential_file_destroy(self.ptr);
+        }
+    }
+}

--- a/tirocks/src/env/sequential_file.rs
+++ b/tirocks/src/env/sequential_file.rs
@@ -1,0 +1,52 @@
+// Copyright 2022 TiKV Project Authors. Licensed under Apache-2.0.
+
+use std::io::{self, Read};
+
+use crate::Result;
+use tirocks_sys::{crocksdb_sequential_file_t, ffi_try};
+
+/// A file abstraction for reading sequentially through a file.
+pub struct SequentialFile {
+    ptr: *mut crocksdb_sequential_file_t,
+}
+
+impl SequentialFile {
+    #[inline]
+    pub(crate) fn from_ptr(ptr: *mut crocksdb_sequential_file_t) -> SequentialFile {
+        SequentialFile { ptr }
+    }
+
+    /// Skip "n" bytes from the file. This is guaranteed to be no
+    /// slower that reading the same data, but may be faster.
+    ///
+    /// If end of file is reached, skipping will stop at the end of the
+    /// file, and Skip will return OK.
+    #[inline]
+    pub fn skip(&mut self, n: usize) -> Result<()> {
+        unsafe {
+            ffi_try!(crocksdb_sequential_file_skip(self.ptr, n));
+            Ok(())
+        }
+    }
+
+    #[inline]
+    fn read(&mut self, buf: &mut [u8]) -> Result<usize> {
+        unsafe {
+            let size = ffi_try! {
+                crocksdb_sequential_file_read(
+                    self.ptr,
+                    buf.len(),
+                    buf.as_mut_ptr() as *mut libc::c_char
+                )
+            };
+            Ok(size as usize)
+        }
+    }
+}
+
+impl Read for SequentialFile {
+    #[inline]
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        Ok(SequentialFile::read(self, buf)?)
+    }
+}

--- a/tirocks/src/env/tests.rs
+++ b/tirocks/src/env/tests.rs
@@ -1,0 +1,99 @@
+use super::*;
+use std::fs::File;
+use std::io::{Read, Write};
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::{Arc, Mutex};
+
+#[test]
+fn test_env_check() {
+    let env = Env::default();
+    env.file_exists("Cargo.toml").unwrap();
+    assert!(env.file_exists("test.file").unwrap_err().path_not_exist());
+}
+
+#[test]
+fn test_mem_check() {
+    let env = Env::with_mem(Env::default());
+    assert!(env.file_exists("Cargo.toml").unwrap_err().path_not_exist());
+}
+
+struct TestDrop {
+    called: Arc<AtomicUsize>,
+}
+
+impl Drop for TestDrop {
+    fn drop(&mut self) {
+        self.called.fetch_add(1, Ordering::SeqCst);
+    }
+}
+
+struct TestFileSystemInspector {
+    pub refill_bytes: usize,
+    pub read_called: usize,
+    pub _drop: Option<TestDrop>,
+}
+
+impl Default for TestFileSystemInspector {
+    fn default() -> Self {
+        TestFileSystemInspector {
+            refill_bytes: 0,
+            read_called: 0,
+            _drop: None,
+        }
+    }
+}
+
+impl FileSystemInspector for Arc<Mutex<TestFileSystemInspector>> {
+    fn read(&self, len: usize) -> Result<usize> {
+        let mut inner = self.lock().unwrap();
+        inner.read_called += 1;
+        if len <= inner.refill_bytes {
+            Ok(len)
+        } else {
+            Err(Status::with_error(
+                Code::kIncomplete,
+                "request exceeds refill bytes",
+            ))
+        }
+    }
+}
+
+#[test]
+fn test_create_and_destroy_inspector() {
+    let drop_called = Arc::new(AtomicUsize::new(0));
+    let fs_inspector = Arc::new(Mutex::new(TestFileSystemInspector {
+        _drop: Some(TestDrop {
+            called: drop_called.clone(),
+        }),
+        ..Default::default()
+    }));
+    let env = Env::with_file_system_inspected(Env::default(), fs_inspector).unwrap();
+    assert_eq!(0, drop_called.load(Ordering::SeqCst));
+    drop(env);
+    assert_eq!(1, drop_called.load(Ordering::SeqCst));
+}
+
+#[test]
+fn test_inspected_operation() {
+    let dir = tempfile::tempdir().unwrap();
+    std::fs::create_dir_all(dir.path()).unwrap();
+    let file_path = dir.path().join("test.txt");
+    File::create(&file_path)
+        .unwrap()
+        .write_all(&[0; 16])
+        .unwrap();
+    let fs_inspector = Arc::new(Mutex::new(TestFileSystemInspector {
+        refill_bytes: 4,
+        ..Default::default()
+    }));
+    let env = Env::with_file_system_inspected(Env::default(), fs_inspector.clone()).unwrap();
+    let mut f = env
+        .new_sequential_file(file_path.to_str().unwrap(), EnvOptions::default())
+        .unwrap();
+    f.read_exact(&mut [0; 2]).unwrap();
+    let e = f.read_exact(&mut [0; 8]).unwrap_err();
+    let msg = format!("{}", e);
+    assert!(msg.contains("refill bytes"), "{}", msg);
+    let record = fs_inspector.lock().unwrap();
+    assert_eq!(2, record.read_called);
+}

--- a/tirocks/src/error.rs
+++ b/tirocks/src/error.rs
@@ -1,0 +1,206 @@
+// Copyright 2022 TiKV Project Authors. Licensed under Apache-2.0.
+
+use std::fmt::{self, Debug};
+use std::io;
+use std::str::Utf8Error;
+
+use tirocks_sys::rocksdb_Status;
+
+/// A safe wrapper around rocksdb::Status.
+#[repr(transparent)]
+pub struct Status(rocksdb_Status);
+
+pub type Code = tirocks_sys::rocksdb_Status_Code;
+pub type Severity = tirocks_sys::rocksdb_Status_Severity;
+pub type SubCode = tirocks_sys::rocksdb_Status_SubCode;
+
+impl Status {
+    #[inline]
+    pub fn with_code(code: Code) -> Status {
+        Status(rocksdb_Status::with_code(code))
+    }
+
+    #[inline]
+    pub fn new(code: Code, sub_code: SubCode, state: impl AsRef<[u8]>) -> Status {
+        let mut s = Status::with_error(code, state);
+        s.set_sub_code(sub_code);
+        s
+    }
+
+    /// Build a status with given errors.
+    ///
+    /// # Panics
+    ///
+    /// `code` should not be `kOK`.
+    #[inline]
+    pub fn with_error(code: Code, state: impl AsRef<[u8]>) -> Status {
+        Status(rocksdb_Status::with_error(code, state))
+    }
+
+    #[inline]
+    pub fn with_no_space(msg: impl AsRef<[u8]>) -> Status {
+        Self::new(Code::kIOError, SubCode::kNoSpace, msg)
+    }
+
+    #[inline]
+    pub fn with_memory_limmit(msg: impl AsRef<[u8]>) -> Status {
+        Self::new(Code::kIOError, SubCode::kMemoryLimit, msg)
+    }
+
+    #[inline]
+    pub fn with_space_limit(msg: impl AsRef<[u8]>) -> Status {
+        Self::new(Code::kIOError, SubCode::kSpaceLimit, msg)
+    }
+
+    #[inline]
+    pub fn with_path_not_found(msg: impl AsRef<[u8]>) -> Status {
+        Self::new(Code::kIOError, SubCode::kPathNotFound, msg)
+    }
+
+    #[inline]
+    pub fn ok(&self) -> bool {
+        self.0.ok()
+    }
+
+    #[inline]
+    pub fn state(&self) -> Option<&[u8]> {
+        self.0.state()
+    }
+
+    #[inline]
+    pub fn message(&self) -> std::result::Result<Option<&str>, Utf8Error> {
+        self.0.message()
+    }
+
+    #[inline]
+    pub fn code(&self) -> Code {
+        self.0.code()
+    }
+
+    #[inline]
+    pub fn severity(&self) -> Severity {
+        self.0.severity()
+    }
+
+    #[inline]
+    pub fn set_severity(&mut self, severity: Severity) {
+        self.0.set_severity(severity);
+    }
+
+    #[inline]
+    pub fn sub_code(&self) -> SubCode {
+        self.0.sub_code()
+    }
+
+    #[inline]
+    pub fn set_sub_code(&mut self, sub_code: SubCode) {
+        self.0.set_sub_code(sub_code)
+    }
+
+    #[inline]
+    pub(crate) fn into_raw(self) -> rocksdb_Status {
+        self.0
+    }
+
+    #[inline]
+    pub fn path_not_exist(&self) -> bool {
+        self.code() == Code::kNotFound
+            || self.code() == Code::kIOError && self.sub_code() == SubCode::kPathNotFound
+    }
+}
+
+impl From<rocksdb_Status> for Status {
+    #[inline]
+    fn from(s: rocksdb_Status) -> Status {
+        Status(s)
+    }
+}
+
+impl From<Status> for io::Error {
+    #[inline]
+    fn from(s: Status) -> Self {
+        let kind = match s.code() {
+            Code::kIOError => match s.sub_code() {
+                #[cfg(feature = "nightly")]
+                SubCode::kNoSpace => io::ErrorKind::StorageFull,
+                #[cfg(feature = "nightly")]
+                SubCode::kSpaceLimit => io::ErrorKind::FilesystemQuotaExceeded,
+                SubCode::kMemoryLimit => io::ErrorKind::OutOfMemory,
+                SubCode::kPathNotFound => io::ErrorKind::NotFound,
+                _ => io::ErrorKind::Other,
+            },
+            Code::kNotFound => io::ErrorKind::NotFound,
+            _ => io::ErrorKind::Other,
+        };
+        let msg = match s.state() {
+            Some(s) => String::from_utf8_lossy(s),
+            None => return Self::from(kind),
+        };
+        Self::new(kind, msg)
+    }
+}
+
+impl Debug for Status {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        if self.ok() {
+            write!(f, "OK")
+        } else {
+            write!(
+                f,
+                "Code: {:?}, SubCode: {:?}, Severity: {:?}, msg: {:?}",
+                self.code(),
+                self.sub_code(),
+                self.severity(),
+                self.message()
+            )
+        }
+    }
+}
+
+pub type Result<T> = std::result::Result<T, Status>;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io;
+
+    #[test]
+    fn test_io_error_transform() {
+        let cases = [
+            (Status::with_code(Code::kBusy), io::ErrorKind::Other, ""),
+            (
+                Status::with_error(Code::kAborted, "test"),
+                io::ErrorKind::Other,
+                "test",
+            ),
+            #[cfg(feature = "nightly")]
+            (
+                Status::with_space_limit("limit"),
+                io::ErrorKind::FilesystemQuotaExceeded,
+                "limit",
+            ),
+            #[cfg(feature = "nightly")]
+            (
+                Status::with_no_space("full"),
+                io::ErrorKind::StorageFull,
+                "full",
+            ),
+            (
+                Status::with_memory_limmit("oom"),
+                io::ErrorKind::OutOfMemory,
+                "oom",
+            ),
+            (
+                Status::with_path_not_found("path"),
+                io::ErrorKind::NotFound,
+                "path",
+            ),
+        ];
+        for (status, kind, pattern) in cases {
+            let e: io::Error = status.into();
+            assert_eq!(e.kind(), kind);
+            let msg = format!("{}", e);
+            assert!(msg.contains(pattern), "{} in {}", pattern, msg);
+        }
+    }
+}

--- a/tirocks/src/lib.rs
+++ b/tirocks/src/lib.rs
@@ -1,8 +1,9 @@
-#[cfg(test)]
-mod tests {
-    #[test]
-    fn it_works() {
-        let result = 2 + 2;
-        assert_eq!(result, 4);
-    }
-}
+// Copyright 2022 TiKV Project Authors. Licensed under Apache-2.0.
+
+#![cfg_attr(feature = "nightly", features(io_error_more))]
+
+pub mod env;
+mod error;
+pub mod rate_limiter;
+
+pub use error::{Code, Result, Severity, Status, SubCode};

--- a/tirocks/src/lib.rs
+++ b/tirocks/src/lib.rs
@@ -1,6 +1,6 @@
 // Copyright 2022 TiKV Project Authors. Licensed under Apache-2.0.
 
-#![cfg_attr(feature = "nightly", features(io_error_more))]
+#![cfg_attr(feature = "nightly", feature(io_error_more))]
 
 pub mod env;
 mod error;

--- a/tirocks/src/rate_limiter.rs
+++ b/tirocks/src/rate_limiter.rs
@@ -1,0 +1,174 @@
+// Copyright 2022 TiKV Project Authors. Licensed under Apache-2.0.
+
+use crate::env::IoPriority;
+use std::marker::PhantomData;
+use std::time::Duration;
+
+pub type RateLimiterMode = tirocks_sys::rocksdb_RateLimiter_Mode;
+pub type OpType = tirocks_sys::rocksdb_RateLimiter_OpType;
+
+pub struct RateLimiterBuilder {
+    /// It controls the total write rate of compaction and flush in bytes per
+    /// second. Currently, RocksDB does not enforce rate limit for anything other
+    /// than flush and compaction, e.g. write to WAL.
+    pub rate_bytes_per_sec: i64,
+    /// It controls how often tokens are refilled. For example, when `rate_bytes_per_sec`
+    /// is set to 10MB/s and refill_period is set to 100ms, then 1MB is refilled every
+    /// 100ms internally. Larger value can lead to burstier writes while smaller value
+    /// introduces more CPU overhead.
+    pub refill_period: Duration,
+    /// RateLimiter accepts high-pri requests and low-pri requests. A low-pri request is
+    /// usually blocked in favor of hi-pri request. Currently, RocksDB assigns low-pri to
+    /// request from compaction and high-pri to request from flush. Low-pri requests can
+    /// get blocked if flush requests come in continuously. This fairness parameter grants
+    /// low-pri requests permission by 1/fairness chance even though high-pri requests
+    /// exist to avoid starvation.
+    pub fairness: i32,
+    /// Mode indicates which types of operations count against the limit.
+    pub mode: RateLimiterMode,
+    /// Enables dynamic adjustment of rate limit within the range
+    /// `[rate_bytes_per_sec / 20, rate_bytes_per_sec]`, according to the recent demand for
+    /// background I/O.
+    pub auto_tuned: bool,
+    // So adding new fields won't be a breaking change in the future.
+    _hidden: PhantomData<()>,
+}
+
+impl RateLimiterBuilder {
+    #[inline]
+    pub fn new(rate_bytes_per_sec: i64) -> RateLimiterBuilder {
+        RateLimiterBuilder {
+            rate_bytes_per_sec,
+            refill_period: Duration::from_millis(100),
+            fairness: 10,
+            mode: RateLimiterMode::kWritesOnly,
+            auto_tuned: false,
+            _hidden: PhantomData,
+        }
+    }
+
+    /// Create a RateLimiter object, which can be shared among RocksDB instances to
+    /// control write rate of flush and compaction.
+    #[inline]
+    pub fn build_generic(&self) -> RateLimiter {
+        let ptr = unsafe {
+            tirocks_sys::crocksdb_ratelimiter_create_with_auto_tuned(
+                self.rate_bytes_per_sec,
+                self.refill_period.as_micros() as i64,
+                self.fairness,
+                self.mode,
+                self.auto_tuned as u8,
+            )
+        };
+        RateLimiter { ptr }
+    }
+
+    /// Similar to generic auto tuned rate limiter, but with following advantages:
+    ///
+    /// - only one important internal knob, easier to tune
+    /// - respond quickly to write flow burst, introduce zero write stall when loading data
+    /// - anti-jitter even when pressure is low
+    #[inline]
+    pub fn build_write_amp_based(&self) -> RateLimiter {
+        let ptr = unsafe {
+            tirocks_sys::crocksdb_writeampbasedratelimiter_create_with_auto_tuned(
+                self.rate_bytes_per_sec,
+                self.refill_period.as_micros() as i64,
+                self.fairness,
+                self.mode,
+                self.auto_tuned as u8,
+            )
+        };
+        RateLimiter { ptr }
+    }
+}
+
+/// A rate limiter can be shared among RocksDB instances to control write
+/// rate of flush and compaction.
+pub struct RateLimiter {
+    ptr: *mut tirocks_sys::crocksdb_ratelimiter_t,
+}
+
+unsafe impl Send for RateLimiter {}
+unsafe impl Sync for RateLimiter {}
+
+impl RateLimiter {
+    /// Dynamically change rate limiter's bytes per second.
+    #[inline]
+    pub fn set_bytes_per_second(&self, bytes_per_sec: i64) {
+        unsafe {
+            tirocks_sys::crocksdb_ratelimiter_set_bytes_per_second(self.ptr, bytes_per_sec);
+        }
+    }
+
+    /// Dynamically change rate limiter's auto_tuned mode.
+    #[inline]
+    pub fn set_auto_tuned(&self, auto_tuned: bool) {
+        unsafe { tirocks_sys::crocksdb_ratelimiter_set_auto_tuned(self.ptr, auto_tuned as u8) }
+    }
+
+    /// Requests token to read or write bytes.
+    ///
+    /// If this request can not be satisfied, the call is blocked. Caller is
+    /// responsible to make sure bytes <= SingleBurstBytes().
+    #[inline]
+    pub fn request(&self, bytes: i64, pri: IoPriority, op_ty: OpType) {
+        unsafe {
+            tirocks_sys::crocksdb_ratelimiter_request(self.ptr, bytes, pri, op_ty);
+        }
+    }
+
+    /// Max bytes can be granted in a single burst
+    #[inline]
+    pub fn single_burst_bytes(&self) -> i64 {
+        unsafe { tirocks_sys::crocksdb_ratelimiter_get_singleburst_bytes(self.ptr) }
+    }
+
+    /// Total bytes that go through rate limiter.
+    pub fn total_bytes_through(&self, pri: IoPriority) -> i64 {
+        unsafe { tirocks_sys::crocksdb_ratelimiter_get_total_bytes_through(self.ptr, pri) }
+    }
+
+    pub fn bytes_per_second(&self) -> i64 {
+        unsafe { tirocks_sys::crocksdb_ratelimiter_get_bytes_per_second(self.ptr) }
+    }
+
+    /// Total count of requests that go through rate limiter
+    pub fn total_requests(&self, pri: IoPriority) -> i64 {
+        unsafe { tirocks_sys::crocksdb_ratelimiter_get_total_requests(self.ptr, pri) }
+    }
+}
+
+impl Drop for RateLimiter {
+    #[inline]
+    fn drop(&mut self) {
+        unsafe { tirocks_sys::crocksdb_ratelimiter_destroy(self.ptr) }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::Instant;
+
+    #[test]
+    fn test_rate_limiter() {
+        let speed = 3000.;
+        let limiter = super::RateLimiterBuilder::new(speed as i64).build_generic();
+        let total_bytes = 6000;
+        let mut consumed = 0;
+        let step = 60;
+        let timer = Instant::now();
+        while consumed < total_bytes {
+            limiter.request(step, IoPriority::IO_HIGH, OpType::kWrite);
+            consumed += step;
+        }
+        let elapsed = timer.elapsed();
+        let actual_speed = consumed as f64 / elapsed.as_secs_f64();
+        assert!(
+            actual_speed < speed * 1.5 && actual_speed > speed * 0.5,
+            "{}",
+            actual_speed
+        );
+    }
+}


### PR DESCRIPTION
Most code are copied from rust-rocksdb/src/env.rs, but with more docs
and refactor.

The most notable differences are:
- Use rocksdb::Env directly instead of custom type;
- Use rocksdb::Status as error handling;
- Files are reorganized following rocksdb's definitions.