### PR TITLE
support encryption env

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,7 +70,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - run: rustup default nightly
+    # See https://github.com/rust-lang/rust/issues/95561
+    - run: rustup default nightly-2022-03-31
     - run: which cargo && cargo version && clang --version && openssl version
     - run: cargo xtask submodule
     - run: RUSTFLAGS="-Z sanitizer=address" cargo test --features encryption,nightly --all --target x86_64-unknown-linux-gnu

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
     - run: sudo update-alternatives --install /usr/bin/clang-tidy clang-tidy /usr/bin/clang-tidy-9 100
     - run: which cargo && cargo version && clang --version && openssl version && which cmake && cmake --version
     - run: cargo xtask submodule
-    - run: cargo clippy --all -- -D clippy::all
+    - run: cargo clippy --all --features encryption -- -D clippy::all
     - run: cargo xtask format && git diff --exit-code HEAD
 
   Linux-Stable:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,8 +70,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    # See https://github.com/rust-lang/rust/issues/95561
-    - run: rustup default nightly-2022-03-31
+    - run: rustup default nightly
     - run: which cargo && cargo version && clang --version && openssl version
     - run: cargo xtask submodule
     - run: RUSTFLAGS="-Z sanitizer=address" cargo test --features encryption,nightly --all --target x86_64-unknown-linux-gnu

--- a/tirocks-sys/bindings/bindings.rs
+++ b/tirocks-sys/bindings/bindings.rs
@@ -110,6 +110,13 @@ pub enum rocksdb_encryption_EncryptionMethod {
     kAES192_CTR = 3,
     kAES256_CTR = 4,
 }
+#[repr(C)]
+pub struct rocksdb_encryption_KeyManager__bindgen_vtable(libc::c_void);
+#[repr(C)]
+#[derive(Debug)]
+pub struct rocksdb_encryption_KeyManager {
+    pub vtable_: *const rocksdb_encryption_KeyManager__bindgen_vtable,
+}
 #[repr(i32)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub enum rocksdb_TableFileCreationReason {
@@ -1131,12 +1138,11 @@ pub enum crocksdb_table_property_t {
 #[repr(C)]
 #[derive(Debug)]
 pub struct crocksdb_file_encryption_info_t {
-    _unused: [u8; 0],
-}
-#[repr(C)]
-#[derive(Debug)]
-pub struct crocksdb_encryption_key_manager_t {
-    _unused: [u8; 0],
+    pub method: rocksdb_encryption_EncryptionMethod,
+    pub key: *const libc::c_char,
+    pub key_len: usize,
+    pub iv: *const libc::c_char,
+    pub iv_len: usize,
 }
 #[repr(C)]
 #[derive(Debug)]
@@ -3931,53 +3937,10 @@ extern "C" {
 extern "C" {
     pub fn crocksdb_sequential_file_destroy(arg1: *mut crocksdb_sequential_file_t);
 }
-extern "C" {
-    pub fn crocksdb_file_encryption_info_create() -> *mut crocksdb_file_encryption_info_t;
-}
-extern "C" {
-    pub fn crocksdb_file_encryption_info_destroy(file_info: *mut crocksdb_file_encryption_info_t);
-}
-extern "C" {
-    pub fn crocksdb_file_encryption_info_method(
-        file_info: *mut crocksdb_file_encryption_info_t,
-    ) -> rocksdb_encryption_EncryptionMethod;
-}
-extern "C" {
-    pub fn crocksdb_file_encryption_info_key(
-        file_info: *mut crocksdb_file_encryption_info_t,
-        keylen: *mut usize,
-    ) -> *const libc::c_char;
-}
-extern "C" {
-    pub fn crocksdb_file_encryption_info_iv(
-        file_info: *mut crocksdb_file_encryption_info_t,
-        ivlen: *mut usize,
-    ) -> *const libc::c_char;
-}
-extern "C" {
-    pub fn crocksdb_file_encryption_info_set_method(
-        file_info: *mut crocksdb_file_encryption_info_t,
-        method: rocksdb_encryption_EncryptionMethod,
-    );
-}
-extern "C" {
-    pub fn crocksdb_file_encryption_info_set_key(
-        file_info: *mut crocksdb_file_encryption_info_t,
-        key: *const libc::c_char,
-        keylen: usize,
-    );
-}
-extern "C" {
-    pub fn crocksdb_file_encryption_info_set_iv(
-        file_info: *mut crocksdb_file_encryption_info_t,
-        iv: *const libc::c_char,
-        ivlen: usize,
-    );
-}
 pub type crocksdb_encryption_key_manager_get_file_cb = ::std::option::Option<
     unsafe extern "C" fn(
         state: *mut libc::c_void,
-        fname: *const libc::c_char,
+        fname: rocksdb_Slice,
         file_info: *mut crocksdb_file_encryption_info_t,
         arg1: *mut rocksdb_Status,
     ),
@@ -3985,23 +3948,19 @@ pub type crocksdb_encryption_key_manager_get_file_cb = ::std::option::Option<
 pub type crocksdb_encryption_key_manager_new_file_cb = ::std::option::Option<
     unsafe extern "C" fn(
         state: *mut libc::c_void,
-        fname: *const libc::c_char,
+        fname: rocksdb_Slice,
         file_info: *mut crocksdb_file_encryption_info_t,
         arg1: *mut rocksdb_Status,
     ),
 >;
 pub type crocksdb_encryption_key_manager_delete_file_cb = ::std::option::Option<
-    unsafe extern "C" fn(
-        state: *mut libc::c_void,
-        fname: *const libc::c_char,
-        arg1: *mut rocksdb_Status,
-    ),
+    unsafe extern "C" fn(state: *mut libc::c_void, fname: rocksdb_Slice, arg1: *mut rocksdb_Status),
 >;
 pub type crocksdb_encryption_key_manager_link_file_cb = ::std::option::Option<
     unsafe extern "C" fn(
         state: *mut libc::c_void,
-        src_fname: *const libc::c_char,
-        dst_fname: *const libc::c_char,
+        src_fname: rocksdb_Slice,
+        dst_fname: rocksdb_Slice,
         arg1: *mut rocksdb_Status,
     ),
 >;
@@ -4013,46 +3972,15 @@ extern "C" {
         new_file: crocksdb_encryption_key_manager_new_file_cb,
         delete_file: crocksdb_encryption_key_manager_delete_file_cb,
         link_file: crocksdb_encryption_key_manager_link_file_cb,
-    ) -> *mut crocksdb_encryption_key_manager_t;
+    ) -> *mut rocksdb_encryption_KeyManager;
 }
 extern "C" {
-    pub fn crocksdb_encryption_key_manager_destroy(arg1: *mut crocksdb_encryption_key_manager_t);
-}
-extern "C" {
-    pub fn crocksdb_encryption_key_manager_get_file(
-        key_manager: *mut crocksdb_encryption_key_manager_t,
-        fname: *const libc::c_char,
-        file_info: *mut crocksdb_file_encryption_info_t,
-        arg1: *mut rocksdb_Status,
-    );
-}
-extern "C" {
-    pub fn crocksdb_encryption_key_manager_new_file(
-        key_manager: *mut crocksdb_encryption_key_manager_t,
-        fname: *const libc::c_char,
-        file_info: *mut crocksdb_file_encryption_info_t,
-        arg1: *mut rocksdb_Status,
-    );
-}
-extern "C" {
-    pub fn crocksdb_encryption_key_manager_delete_file(
-        key_manager: *mut crocksdb_encryption_key_manager_t,
-        fname: *const libc::c_char,
-        arg1: *mut rocksdb_Status,
-    );
-}
-extern "C" {
-    pub fn crocksdb_encryption_key_manager_link_file(
-        key_manager: *mut crocksdb_encryption_key_manager_t,
-        src_fname: *const libc::c_char,
-        dst_fname: *const libc::c_char,
-        arg1: *mut rocksdb_Status,
-    );
+    pub fn crocksdb_encryption_key_manager_destroy(arg1: *mut rocksdb_encryption_KeyManager);
 }
 extern "C" {
     pub fn crocksdb_key_managed_encrypted_env_create(
         arg1: *mut rocksdb_Env,
-        arg2: *mut crocksdb_encryption_key_manager_t,
+        arg2: *mut rocksdb_encryption_KeyManager,
     ) -> *mut rocksdb_Env;
 }
 pub type crocksdb_file_system_inspector_read_cb = ::std::option::Option<

--- a/tirocks-sys/bindings/bindings.rs
+++ b/tirocks-sys/bindings/bindings.rs
@@ -1187,15 +1187,6 @@ pub enum crocksdb_table_property_t {
 }
 #[repr(C)]
 #[derive(Debug)]
-pub struct crocksdb_file_encryption_info_t {
-    pub method: rocksdb_encryption_EncryptionMethod,
-    pub key: *const libc::c_char,
-    pub key_len: usize,
-    pub iv: *const libc::c_char,
-    pub iv_len: usize,
-}
-#[repr(C)]
-#[derive(Debug)]
 pub struct crocksdb_file_system_inspector_t {
     _unused: [u8; 0],
 }
@@ -3803,11 +3794,19 @@ extern "C" {
 extern "C" {
     pub fn crocksdb_sequential_file_destroy(arg1: *mut crocksdb_sequential_file_t);
 }
+extern "C" {
+    pub fn crocksdb_file_encryption_info_init(
+        info: *mut rocksdb_encryption_FileEncryptionInfo,
+        method: rocksdb_encryption_EncryptionMethod,
+        key: rocksdb_Slice,
+        iv: rocksdb_Slice,
+    );
+}
 pub type crocksdb_encryption_key_manager_get_file_cb = ::std::option::Option<
     unsafe extern "C" fn(
         state: *mut libc::c_void,
         fname: rocksdb_Slice,
-        file_info: *mut crocksdb_file_encryption_info_t,
+        file_info: *mut rocksdb_encryption_FileEncryptionInfo,
         arg1: *mut rocksdb_Status,
     ),
 >;
@@ -3815,7 +3814,7 @@ pub type crocksdb_encryption_key_manager_new_file_cb = ::std::option::Option<
     unsafe extern "C" fn(
         state: *mut libc::c_void,
         fname: rocksdb_Slice,
-        file_info: *mut crocksdb_file_encryption_info_t,
+        file_info: *mut rocksdb_encryption_FileEncryptionInfo,
         arg1: *mut rocksdb_Status,
     ),
 >;

--- a/tirocks-sys/build.rs
+++ b/tirocks-sys/build.rs
@@ -43,12 +43,12 @@ fn bindgen_rocksdb(file_path: &Path) {
         .allowlist_type(r"\brocksdb::titandb::HistogramType")
         .opaque_type(r"\brocksdb::Env")
         // Just blocking the type will still include its dependencies.
-        .opaque_type(r"\brocksdb::TableProperties")
+        .opaque_type(r"\brocksdb::(TableProperties|encryption::FileEncryptionInfo)")
         // Block all system headers
         .blocklist_file(r"^/.*")
         .blocklist_type(r"\brocksdb::Env_FileAttributes")
         // `TableProperties` has different size on different platform.
-        .blocklist_type(r"\brocksdb::TableProperties")
+        .blocklist_type(r"\brocksdb::(TableProperties|encryption::FileEncryptionInfo)")
         .with_codegen_config(
             bindgen::CodegenConfig::FUNCTIONS
                 | bindgen::CodegenConfig::VARS

--- a/tirocks-sys/crocksdb/c.cc
+++ b/tirocks-sys/crocksdb/c.cc
@@ -3799,11 +3799,12 @@ void crocksdb_sequential_file_destroy(crocksdb_sequential_file_t* file) {
 }
 
 #ifdef OPENSSL
-inline void file_encryption_info_to_cpp(
-    const crocksdb_file_encryption_info_t& src, FileEncryptionInfo* dst) {
-  dst->method = src.method;
-  dst->key = std::string(src.key, src.key_len);
-  dst->iv = std::string(src.iv, src.iv_len);
+void crocksdb_file_encryption_info_init(FileEncryptionInfo* info,
+                                        EncryptionMethod method, Slice key,
+                                        Slice iv) {
+  info->method = method;
+  info->key = key.ToString();
+  info->iv = iv.ToString();
 }
 
 struct crocksdb_encryption_key_manager_impl_t : public KeyManager {
@@ -3816,21 +3817,15 @@ struct crocksdb_encryption_key_manager_impl_t : public KeyManager {
 
   virtual ~crocksdb_encryption_key_manager_impl_t() { destructor(state); }
 
-  Status GetFile(const std::string& fname,
-                 FileEncryptionInfo* file_info) override {
+  Status GetFile(const std::string& fname, FileEncryptionInfo* info) override {
     Status s;
-    crocksdb_file_encryption_info_t info;
-    get_file(state, fname, &info, &s);
-    file_encryption_info_to_cpp(info, file_info);
+    get_file(state, fname, info, &s);
     return s;
   }
 
-  Status NewFile(const std::string& fname,
-                 FileEncryptionInfo* file_info) override {
+  Status NewFile(const std::string& fname, FileEncryptionInfo* info) override {
     Status s;
-    crocksdb_file_encryption_info_t info;
-    new_file(state, fname, &info, &s);
-    file_encryption_info_to_cpp(info, file_info);
+    new_file(state, fname, info, &s);
     return s;
   }
 

--- a/tirocks-sys/crocksdb/c.cc
+++ b/tirocks-sys/crocksdb/c.cc
@@ -752,16 +752,6 @@ struct crocksdb_writebatch_iterator_t {
   rocksdb::WriteBatch::Iterator* rep;
 };
 
-#ifdef OPENSSL
-struct crocksdb_file_encryption_info_t {
-  FileEncryptionInfo* rep;
-};
-
-struct crocksdb_encryption_key_manager_t {
-  std::shared_ptr<KeyManager> rep;
-};
-#endif
-
 struct crocksdb_sst_partitioner_t {
   std::unique_ptr<SstPartitioner> rep;
 };
@@ -4023,61 +4013,11 @@ void crocksdb_sequential_file_destroy(crocksdb_sequential_file_t* file) {
 }
 
 #ifdef OPENSSL
-crocksdb_file_encryption_info_t* crocksdb_file_encryption_info_create() {
-  crocksdb_file_encryption_info_t* file_info =
-      new crocksdb_file_encryption_info_t;
-  file_info->rep = new FileEncryptionInfo;
-  return file_info;
-}
-
-void crocksdb_file_encryption_info_destroy(
-    crocksdb_file_encryption_info_t* file_info) {
-  delete file_info->rep;
-  delete file_info;
-}
-
-EncryptionMethod crocksdb_file_encryption_info_method(
-    crocksdb_file_encryption_info_t* file_info) {
-  assert(file_info != nullptr);
-  assert(file_info->rep != nullptr);
-  return file_info->rep->method;
-}
-
-const char* crocksdb_file_encryption_info_key(
-    crocksdb_file_encryption_info_t* file_info, size_t* keylen) {
-  assert(file_info != nullptr);
-  assert(file_info->rep != nullptr);
-  assert(keylen != nullptr);
-  *keylen = file_info->rep->key.size();
-  return file_info->rep->key.c_str();
-}
-
-const char* crocksdb_file_encryption_info_iv(
-    crocksdb_file_encryption_info_t* file_info, size_t* ivlen) {
-  assert(file_info != nullptr);
-  assert(file_info->rep != nullptr);
-  assert(ivlen != nullptr);
-  *ivlen = file_info->rep->iv.size();
-  return file_info->rep->iv.c_str();
-}
-
-void crocksdb_file_encryption_info_set_method(
-    crocksdb_file_encryption_info_t* file_info, EncryptionMethod method) {
-  assert(file_info != nullptr);
-  file_info->rep->method = method;
-}
-
-void crocksdb_file_encryption_info_set_key(
-    crocksdb_file_encryption_info_t* file_info, const char* key,
-    size_t keylen) {
-  assert(file_info != nullptr);
-  file_info->rep->key = std::string(key, keylen);
-}
-
-void crocksdb_file_encryption_info_set_iv(
-    crocksdb_file_encryption_info_t* file_info, const char* iv, size_t ivlen) {
-  assert(file_info != nullptr);
-  file_info->rep->iv = std::string(iv, ivlen);
+inline void file_encryption_info_to_cpp(
+    const crocksdb_file_encryption_info_t& src, FileEncryptionInfo* dst) {
+  dst->method = src.method;
+  dst->key = std::string(src.key, src.key_len);
+  dst->iv = std::string(src.iv, src.iv_len);
 }
 
 struct crocksdb_encryption_key_manager_impl_t : public KeyManager {
@@ -4092,88 +4032,60 @@ struct crocksdb_encryption_key_manager_impl_t : public KeyManager {
 
   Status GetFile(const std::string& fname,
                  FileEncryptionInfo* file_info) override {
-    crocksdb_file_encryption_info_t info;
-    info.rep = file_info;
     Status s;
-    get_file(state, fname.c_str(), &info, &s);
+    crocksdb_file_encryption_info_t info;
+    get_file(state, fname, &info, &s);
+    file_encryption_info_to_cpp(info, file_info);
     return s;
   }
 
   Status NewFile(const std::string& fname,
                  FileEncryptionInfo* file_info) override {
-    crocksdb_file_encryption_info_t info;
-    info.rep = file_info;
     Status s;
-    new_file(state, fname.c_str(), &info, &s);
+    crocksdb_file_encryption_info_t info;
+    new_file(state, fname, &info, &s);
+    file_encryption_info_to_cpp(info, file_info);
     return s;
   }
 
   Status DeleteFile(const std::string& fname) override {
     Status s;
-    delete_file(state, fname.c_str(), &s);
+    delete_file(state, fname, &s);
     return s;
   }
 
   Status LinkFile(const std::string& src_fname,
                   const std::string& dst_fname) override {
     Status s;
-    link_file(state, src_fname.c_str(), dst_fname.c_str(), &s);
+    link_file(state, src_fname, dst_fname, &s);
     return s;
   }
 };
 
-crocksdb_encryption_key_manager_t* crocksdb_encryption_key_manager_create(
+KeyManager* crocksdb_encryption_key_manager_create(
     void* state, void (*destructor)(void*),
     crocksdb_encryption_key_manager_get_file_cb get_file,
     crocksdb_encryption_key_manager_new_file_cb new_file,
     crocksdb_encryption_key_manager_delete_file_cb delete_file,
     crocksdb_encryption_key_manager_link_file_cb link_file) {
-  std::shared_ptr<crocksdb_encryption_key_manager_impl_t> key_manager_impl =
-      std::make_shared<crocksdb_encryption_key_manager_impl_t>();
+  auto key_manager_impl = new crocksdb_encryption_key_manager_impl_t;
   key_manager_impl->state = state;
   key_manager_impl->destructor = destructor;
   key_manager_impl->get_file = get_file;
   key_manager_impl->new_file = new_file;
   key_manager_impl->delete_file = delete_file;
   key_manager_impl->link_file = link_file;
-  crocksdb_encryption_key_manager_t* key_manager =
-      new crocksdb_encryption_key_manager_t;
-  key_manager->rep = key_manager_impl;
-  return key_manager;
+  return key_manager_impl;
 }
 
-void crocksdb_encryption_key_manager_destroy(
-    crocksdb_encryption_key_manager_t* key_manager) {
+void crocksdb_encryption_key_manager_destroy(KeyManager* key_manager) {
   delete key_manager;
 }
 
-void crocksdb_encryption_key_manager_get_file(
-    crocksdb_encryption_key_manager_t* key_manager, const char* fname,
-    crocksdb_file_encryption_info_t* file_info, Status* s) {
-  *s = key_manager->rep->GetFile(fname, file_info->rep);
-}
-
-void crocksdb_encryption_key_manager_new_file(
-    crocksdb_encryption_key_manager_t* key_manager, const char* fname,
-    crocksdb_file_encryption_info_t* file_info, Status* s) {
-  *s = key_manager->rep->NewFile(fname, file_info->rep);
-}
-
-void crocksdb_encryption_key_manager_delete_file(
-    crocksdb_encryption_key_manager_t* key_manager, const char* fname,
-    Status* s) {
-  *s = key_manager->rep->DeleteFile(fname);
-}
-
-void crocksdb_encryption_key_manager_link_file(
-    crocksdb_encryption_key_manager_t* key_manager, const char* src_fname,
-    const char* dst_fname, Status* s) {
-  *s = key_manager->rep->LinkFile(src_fname, dst_fname);
-}
-
-Env* crocksdb_key_managed_encrypted_env_create(
-    Env* base_env, crocksdb_encryption_key_manager_t* key_manager) {
-  return NewKeyManagedEncryptedEnv(base_env, key_manager->rep);
+Env* crocksdb_key_managed_encrypted_env_create(Env* base_env,
+                                               KeyManager* key_manager) {
+  std::shared_ptr<KeyManager> p(key_manager);
+  return NewKeyManagedEncryptedEnv(base_env, p);
 }
 #endif
 

--- a/tirocks-sys/crocksdb/crocksdb/c.h
+++ b/tirocks-sys/crocksdb/crocksdb/c.h
@@ -238,16 +238,6 @@ typedef enum crocksdb_table_property_t {
   kCompressionName = 17,
 } crocksdb_table_property_t;
 
-#ifdef OPENSSL
-typedef struct crocksdb_file_encryption_info_t {
-  EncryptionMethod method = EncryptionMethod::kUnknown;
-  const char* key;
-  size_t key_len;
-  const char* iv;
-  size_t iv_len;
-} crocksdb_file_encryption_info_t;
-#endif
-
 typedef struct crocksdb_file_system_inspector_t
     crocksdb_file_system_inspector_t;
 
@@ -1537,13 +1527,12 @@ extern C_ROCKSDB_LIBRARY_API void crocksdb_sequential_file_destroy(
 /* KeyManagedEncryptedEnv */
 
 #ifdef OPENSSL
-
+extern C_ROCKSDB_LIBRARY_API void crocksdb_file_encryption_info_init(
+    FileEncryptionInfo* info, EncryptionMethod method, Slice key, Slice iv);
 typedef void (*crocksdb_encryption_key_manager_get_file_cb)(
-    void* state, Slice fname, crocksdb_file_encryption_info_t* file_info,
-    Status*);
+    void* state, Slice fname, FileEncryptionInfo* file_info, Status*);
 typedef void (*crocksdb_encryption_key_manager_new_file_cb)(
-    void* state, Slice fname, crocksdb_file_encryption_info_t* file_info,
-    Status*);
+    void* state, Slice fname, FileEncryptionInfo* file_info, Status*);
 typedef void (*crocksdb_encryption_key_manager_delete_file_cb)(void* state,
                                                                Slice fname,
                                                                Status*);

--- a/tirocks-sys/src/lib.rs
+++ b/tirocks-sys/src/lib.rs
@@ -10,6 +10,10 @@ extern crate bzip2_sys;
 
 #[allow(clippy::all)]
 mod bindings {
+    // We don't want it be generated as it has different size on different platform
+    // so we declare it manually.
+    pub enum rocksdb_encryption_FileEncryptionInfo {}
+
     include!(env!("BINDING_PATH"));
 }
 

--- a/tirocks/Cargo.toml
+++ b/tirocks/Cargo.toml
@@ -8,6 +8,7 @@ keywords = ["rocksdb", "bindings"]
 
 [features]
 nightly = []
+encryption = ["tirocks-sys/encryption"]
 
 [dependencies]
 libc = "0.2.11"

--- a/tirocks/src/encryption.rs
+++ b/tirocks/src/encryption.rs
@@ -227,7 +227,11 @@ mod test {
                 EncryptionMethod::kPlaintext
             };
             // Set arbitrary key and iv to detect UAF
-            Ok(FileEncryptionInfo::new(method, vec![1, 2, 3, 4], vec![1, 2, 3, 4]))
+            Ok(FileEncryptionInfo::new(
+                method,
+                vec![1, 2, 3, 4],
+                vec![1, 2, 3, 4],
+            ))
         }
 
         fn new_file(&self, _: &str) -> Result<FileEncryptionInfo> {
@@ -238,7 +242,11 @@ mod test {
                 EncryptionMethod::kPlaintext
             };
             // Set arbitrary key and iv to detect UAF
-            Ok(FileEncryptionInfo::new(method, vec![1, 2, 3, 4], vec![1, 2, 3, 4]))
+            Ok(FileEncryptionInfo::new(
+                method,
+                vec![1, 2, 3, 4],
+                vec![1, 2, 3, 4],
+            ))
         }
 
         fn delete_file(&self, _: &str) -> Result<()> {

--- a/tirocks/src/encryption.rs
+++ b/tirocks/src/encryption.rs
@@ -1,0 +1,295 @@
+// Copyright 2022 TiKV Project Authors. Licensed under Apache-2.0.
+
+use std::fmt::{self, Debug, Formatter};
+use std::{mem, ptr};
+
+use crate::util::utf8_name;
+use crate::{Code, Result, Status};
+use libc::c_void;
+use tirocks_sys::{
+    crocksdb_file_encryption_info_t, rocksdb_Slice, rocksdb_Status,
+    rocksdb_encryption_EncryptionMethod, rocksdb_encryption_KeyManager,
+};
+
+pub type EncryptionMethod = rocksdb_encryption_EncryptionMethod;
+
+#[derive(Clone, PartialEq, Eq)]
+pub struct FileEncryptionInfo {
+    method: EncryptionMethod,
+    key: Vec<u8>,
+    iv: Vec<u8>,
+}
+
+impl FileEncryptionInfo {
+    #[inline]
+    pub fn new(method: EncryptionMethod, key: Vec<u8>, iv: Vec<u8>) -> FileEncryptionInfo {
+        FileEncryptionInfo { method, key, iv }
+    }
+
+    #[inline]
+    pub fn method(&self) -> EncryptionMethod {
+        self.method
+    }
+
+    #[inline]
+    pub fn key(&self) -> &[u8] {
+        &self.key
+    }
+
+    #[inline]
+    pub fn iv(&self) -> &[u8] {
+        &self.iv
+    }
+
+    unsafe fn copy_to(&self, file_info: *mut crocksdb_file_encryption_info_t) {
+        let info = &mut *file_info;
+        info.method = self.method;
+        info.key = self.key.as_ptr() as _;
+        info.key_len = self.key.len();
+        info.iv = self.iv.as_ptr() as _;
+        info.iv_len = self.iv.len();
+    }
+}
+
+impl Debug for FileEncryptionInfo {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+        write!(
+            f,
+            "FileEncryptionInfo [method={:?}, key=...<{} bytes>, iv=...<{} bytes>]",
+            self.method,
+            self.key.len(),
+            self.iv.len()
+        )
+    }
+}
+
+/// Manage encryption keys for files. `Env` will query KeyManager for the
+/// key being used for each file, and update KeyManager when it creates a
+/// new file or moving files around.
+pub trait KeyManager: Sync + Send {
+    fn get_file(&self, file_name: &str) -> Result<FileEncryptionInfo>;
+    fn new_file(&self, file_name: &str) -> Result<FileEncryptionInfo>;
+    fn delete_file(&self, file_name: &str) -> Result<()>;
+    fn link_file(&self, src_file_name: &str, dst_file_name: &str) -> Result<()>;
+}
+
+extern "C" fn key_manager_destructor<T: KeyManager>(ctx: *mut c_void) {
+    unsafe {
+        // Recover from raw pointer and implicitly drop.
+        drop(Box::from_raw(ctx as *mut T));
+    }
+}
+
+extern "C" fn key_manager_get_file<T: KeyManager>(
+    ctx: *mut c_void,
+    file_name: rocksdb_Slice,
+    file_info: *mut crocksdb_file_encryption_info_t,
+    status: *mut rocksdb_Status,
+) {
+    unsafe {
+        let key_manager = &*(ctx as *mut T);
+        let name = utf8_name!(file_name, "Encryption file name", status);
+
+        match key_manager.get_file(name) {
+            Ok(ret) => {
+                ret.copy_to(file_info);
+                *status = Status::with_code(Code::kOk).into_raw();
+            }
+            Err(err) => *status = err.into_raw(),
+        }
+    }
+}
+
+extern "C" fn key_manager_new_file<T: KeyManager>(
+    ctx: *mut c_void,
+    file_name: rocksdb_Slice,
+    file_info: *mut crocksdb_file_encryption_info_t,
+    status: *mut rocksdb_Status,
+) {
+    unsafe {
+        let key_manager = &*(ctx as *mut T);
+        let name = utf8_name!(file_name, "Encryption file name", status);
+
+        match key_manager.new_file(name) {
+            Ok(ret) => {
+                ret.copy_to(file_info);
+                *status = Status::with_code(Code::kOk).into_raw();
+            }
+            Err(err) => *status = err.into_raw(),
+        }
+    }
+}
+
+extern "C" fn key_manager_delete_file<T: KeyManager>(
+    ctx: *mut c_void,
+    file_name: rocksdb_Slice,
+    status: *mut rocksdb_Status,
+) {
+    unsafe {
+        let key_manager = &*(ctx as *mut T);
+        let name = utf8_name!(file_name, "Encryption file name", status);
+        match key_manager.delete_file(name) {
+            Ok(()) => ptr::write(status, Status::with_code(Code::kOk).into_raw()),
+            Err(err) => ptr::write(status, err.into_raw()),
+        }
+    }
+}
+
+extern "C" fn key_manager_link_file<T: KeyManager>(
+    ctx: *mut c_void,
+    src: rocksdb_Slice,
+    dst: rocksdb_Slice,
+    status: *mut rocksdb_Status,
+) {
+    unsafe {
+        let key_manager = &*(ctx as *mut T);
+        let src_name = utf8_name!(src, "Encryption file name", status);
+        let dst_name = utf8_name!(dst, "Encryption file name", status);
+        match key_manager.link_file(src_name, dst_name) {
+            Ok(()) => ptr::write(status, Status::with_code(Code::kOk).into_raw()),
+            Err(err) => ptr::write(status, err.into_raw()),
+        }
+    }
+}
+
+pub(crate) struct SysKeyManager {
+    ptr: *mut rocksdb_encryption_KeyManager,
+}
+
+unsafe impl Send for SysKeyManager {}
+unsafe impl Sync for SysKeyManager {}
+
+impl SysKeyManager {
+    pub fn new<T: KeyManager>(key_manager: T) -> SysKeyManager {
+        let ctx = Box::into_raw(Box::new(key_manager)) as *mut c_void;
+        let ptr = unsafe {
+            tirocks_sys::crocksdb_encryption_key_manager_create(
+                ctx,
+                Some(key_manager_destructor::<T>),
+                Some(key_manager_get_file::<T>),
+                Some(key_manager_new_file::<T>),
+                Some(key_manager_delete_file::<T>),
+                Some(key_manager_link_file::<T>),
+            )
+        };
+        SysKeyManager { ptr }
+    }
+
+    #[inline]
+    pub(crate) fn into_raw(self) -> *mut rocksdb_encryption_KeyManager {
+        let p = self.ptr;
+        mem::forget(self);
+        p
+    }
+}
+
+impl Drop for SysKeyManager {
+    fn drop(&mut self) {
+        unsafe {
+            tirocks_sys::crocksdb_encryption_key_manager_destroy(self.ptr);
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use std::fs::File;
+    use std::io::{Read, Write};
+    use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+    use std::sync::Arc;
+
+    use crate::env::{Env, EnvOptions};
+
+    use super::*;
+
+    #[derive(Default)]
+    struct AccessRecord {
+        drop: AtomicBool,
+        invalid_encrypted: AtomicBool,
+        get_access: AtomicUsize,
+        new_access: AtomicUsize,
+        delete_access: AtomicUsize,
+        link_access: AtomicUsize,
+    }
+
+    #[derive(Default)]
+    struct TestKeyManager {
+        record: Arc<AccessRecord>,
+    }
+
+    impl KeyManager for TestKeyManager {
+        fn get_file(&self, _: &str) -> Result<FileEncryptionInfo> {
+            self.record.get_access.fetch_add(1, Ordering::SeqCst);
+            let method = if self.record.invalid_encrypted.load(Ordering::SeqCst) {
+                EncryptionMethod::kUnknown
+            } else {
+                EncryptionMethod::kPlaintext
+            };
+            Ok(FileEncryptionInfo::new(method, vec![], vec![]))
+        }
+
+        fn new_file(&self, _: &str) -> Result<FileEncryptionInfo> {
+            self.record.new_access.fetch_add(1, Ordering::SeqCst);
+            let method = if self.record.invalid_encrypted.load(Ordering::SeqCst) {
+                EncryptionMethod::kUnknown
+            } else {
+                EncryptionMethod::kPlaintext
+            };
+            Ok(FileEncryptionInfo::new(method, vec![], vec![]))
+        }
+
+        fn delete_file(&self, _: &str) -> Result<()> {
+            self.record.delete_access.fetch_add(1, Ordering::SeqCst);
+            Ok(())
+        }
+
+        fn link_file(&self, _: &str, _: &str) -> Result<()> {
+            self.record.link_access.fetch_add(1, Ordering::SeqCst);
+            Ok(())
+        }
+    }
+
+    impl Drop for TestKeyManager {
+        fn drop(&mut self) {
+            self.record.drop.store(true, Ordering::SeqCst);
+        }
+    }
+
+    #[test]
+    fn test_encrypted_manager() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(dir.path()).unwrap();
+        let file_path = dir.path().join("test.txt");
+        let file_path_str = file_path.to_str().unwrap();
+        let data = [0; 16];
+        File::create(&file_path).unwrap().write_all(&data).unwrap();
+
+        let key_manager = TestKeyManager::default();
+        let record = key_manager.record.clone();
+        let env = Env::with_key_manager_encrypted(Env::default(), key_manager).unwrap();
+        assert!(!record.drop.load(Ordering::SeqCst));
+        assert_eq!(record.get_access.load(Ordering::SeqCst), 0);
+        record.invalid_encrypted.store(true, Ordering::SeqCst);
+        let status = env
+            .new_sequential_file(file_path_str, EnvOptions::default())
+            .unwrap_err();
+        assert_eq!(status.code(), Code::kInvalidArgument);
+        assert_eq!(record.get_access.load(Ordering::SeqCst), 1);
+
+        record.invalid_encrypted.store(false, Ordering::SeqCst);
+        let mut f = env
+            .new_sequential_file(file_path_str, EnvOptions::default())
+            .unwrap();
+        let mut buf = [3; 16];
+        f.read_exact(&mut buf).unwrap();
+        assert_eq!(buf, data);
+        assert_eq!(record.get_access.load(Ordering::SeqCst), 2);
+
+        assert_eq!(record.delete_access.load(Ordering::SeqCst), 0);
+        env.delete_file(file_path_str).unwrap();
+        assert_eq!(record.delete_access.load(Ordering::SeqCst), 1);
+
+        drop(env);
+        assert!(record.drop.load(Ordering::SeqCst));
+    }
+}

--- a/tirocks/src/env/sequential_file.rs
+++ b/tirocks/src/env/sequential_file.rs
@@ -6,6 +6,7 @@ use crate::{error::ffi_call, Result};
 use tirocks_sys::crocksdb_sequential_file_t;
 
 /// A file abstraction for reading sequentially through a file.
+#[derive(Debug)]
 pub struct SequentialFile {
     ptr: *mut crocksdb_sequential_file_t,
 }

--- a/tirocks/src/error.rs
+++ b/tirocks/src/error.rs
@@ -43,6 +43,11 @@ impl Status {
     }
 
     #[inline]
+    pub fn with_invalid_argument(msg: impl AsRef<[u8]>) -> Status {
+        Self::new(Code::kInvalidArgument, SubCode::kNone, msg)
+    }
+
+    #[inline]
     pub fn with_memory_limmit(msg: impl AsRef<[u8]>) -> Status {
         Self::new(Code::kIOError, SubCode::kMemoryLimit, msg)
     }

--- a/tirocks/src/lib.rs
+++ b/tirocks/src/lib.rs
@@ -2,8 +2,11 @@
 
 #![cfg_attr(feature = "nightly", feature(io_error_more))]
 
+#[cfg(feature = "encryption")]
+pub mod encryption;
 pub mod env;
 mod error;
 pub mod rate_limiter;
+mod util;
 
 pub use error::{Code, Result, Severity, Status, SubCode};

--- a/tirocks/src/util.rs
+++ b/tirocks/src/util.rs
@@ -1,0 +1,21 @@
+// Copyright 2022 TiKV Project Authors. Licensed under Apache-2.0.
+
+// For now the macro is only used by encryption.
+#![cfg_attr(not(feature = "encryption"), allow(unused))]
+
+macro_rules! utf8_name {
+    ($slice:expr, $ctx:expr, $status:expr) => {
+        match std::str::from_utf8(tirocks_sys::s($slice)) {
+            Ok(n) => n,
+            Err(e) => {
+                std::ptr::write(
+                    $status,
+                    Status::with_invalid_argument(format!("{}: {}", $ctx, e)).into_raw(),
+                );
+                return;
+            }
+        }
+    };
+}
+
+pub(crate) use utf8_name;


### PR DESCRIPTION
Most code is ported from https://github.com/tikv/rust-rocksdb/blob/master/src/encryption.rs, with following modifications:

- Remove several bindings for testing only.
- Use ordinary pointer instead of share pointers.