### PR TITLE
support read write options

### DIFF
--- a/tirocks-sys/bindings/bindings.rs
+++ b/tirocks-sys/bindings/bindings.rs
@@ -110,6 +110,7 @@ pub enum rocksdb_encryption_EncryptionMethod {
     kAES192_CTR = 3,
     kAES256_CTR = 4,
 }
+pub type rocksdb_SequenceNumber = u64;
 #[repr(i32)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub enum rocksdb_TableFileCreationReason {
@@ -117,6 +118,11 @@ pub enum rocksdb_TableFileCreationReason {
     kCompaction = 1,
     kRecovery = 2,
     kMisc = 3,
+}
+#[repr(C)]
+#[repr(align(8))]
+pub struct rocksdb_TableProperties {
+    pub _bindgen_opaque_blob: [u64; 53usize],
 }
 #[repr(i32)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
@@ -480,6 +486,11 @@ pub enum rocksdb_Histograms {
     DB_WRITE_WAL_TIME = 48,
     HISTOGRAM_ENUM_MAX = 49,
 }
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct rocksdb_Snapshot {
+    _unused: [u8; 0],
+}
 #[repr(u8)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub enum rocksdb_CompressionType {
@@ -510,6 +521,51 @@ pub enum rocksdb_ReadTier {
     kPersistedTier = 2,
     kMemtableTier = 3,
 }
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct rocksdb_ReadOptions {
+    pub snapshot: *const rocksdb_Snapshot,
+    pub iterate_lower_bound: *const rocksdb_Slice,
+    pub iterate_upper_bound: *const rocksdb_Slice,
+    pub readahead_size: usize,
+    pub max_skippable_internal_keys: u64,
+    pub read_tier: rocksdb_ReadTier,
+    pub verify_checksums: bool,
+    pub fill_cache: bool,
+    pub tailing: bool,
+    pub managed: bool,
+    pub total_order_seek: bool,
+    pub prefix_same_as_start: bool,
+    pub pin_data: bool,
+    pub background_purge_on_iterator_cleanup: bool,
+    pub ignore_range_deletions: bool,
+    pub table_filter: [u64; 4usize],
+    pub iter_start_seqnum: rocksdb_SequenceNumber,
+    pub timestamp: *const rocksdb_Slice,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct rocksdb_WriteOptions {
+    pub sync: bool,
+    pub disableWAL: bool,
+    pub ignore_missing_column_families: bool,
+    pub no_slowdown: bool,
+    pub low_pri: bool,
+    pub timestamp: *const rocksdb_Slice,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct rocksdb_FlushOptions {
+    pub wait: bool,
+    pub allow_write_stall: bool,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct rocksdb_CompactionOptions {
+    pub compression: rocksdb_CompressionType,
+    pub output_file_size_limit: u64,
+    pub max_subcompactions: u32,
+}
 #[repr(i32)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub enum rocksdb_BottommostLevelCompaction {
@@ -517,6 +573,29 @@ pub enum rocksdb_BottommostLevelCompaction {
     kIfHaveCompactionFilter = 1,
     kForce = 2,
     kForceOptimized = 3,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct rocksdb_CompactRangeOptions {
+    pub exclusive_manual_compaction: bool,
+    pub change_level: bool,
+    pub target_level: libc::c_int,
+    pub target_path_id: u32,
+    pub bottommost_level_compaction: rocksdb_BottommostLevelCompaction,
+    pub allow_write_stall: bool,
+    pub max_subcompactions: u32,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct rocksdb_IngestExternalFileOptions {
+    pub move_files: bool,
+    pub failed_move_fall_back_to_copy: bool,
+    pub snapshot_consistency: bool,
+    pub allow_global_seqno: bool,
+    pub allow_blocking_flush: bool,
+    pub ingest_behind: bool,
+    pub write_global_seqno: bool,
+    pub verify_checksums_before_ingest: bool,
 }
 #[repr(u8)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
@@ -556,6 +635,12 @@ pub enum rocksdb_titandb_TitanBlobRunMode {
     kNormal = 0,
     kReadOnly = 1,
     kFallback = 2,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct rocksdb_titandb_TitanReadOptions {
+    pub _base: rocksdb_ReadOptions,
+    pub key_only: bool,
 }
 #[repr(u32)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
@@ -685,11 +770,6 @@ pub struct crocksdb_filterpolicy_t {
 }
 #[repr(C)]
 #[derive(Debug)]
-pub struct crocksdb_flushoptions_t {
-    _unused: [u8; 0],
-}
-#[repr(C)]
-#[derive(Debug)]
 pub struct crocksdb_iterator_t {
     _unused: [u8; 0],
 }
@@ -720,11 +800,6 @@ pub struct crocksdb_column_family_descriptor {
 }
 #[repr(C)]
 #[derive(Debug)]
-pub struct crocksdb_compactoptions_t {
-    _unused: [u8; 0],
-}
-#[repr(C)]
-#[derive(Debug)]
 pub struct crocksdb_block_based_table_options_t {
     _unused: [u8; 0],
 }
@@ -736,11 +811,6 @@ pub struct crocksdb_cuckoo_table_options_t {
 #[repr(C)]
 #[derive(Debug)]
 pub struct crocksdb_randomfile_t {
-    _unused: [u8; 0],
-}
-#[repr(C)]
-#[derive(Debug)]
-pub struct crocksdb_readoptions_t {
     _unused: [u8; 0],
 }
 #[repr(C)]
@@ -770,11 +840,6 @@ pub struct crocksdb_writebatch_t {
 }
 #[repr(C)]
 #[derive(Debug)]
-pub struct crocksdb_writeoptions_t {
-    _unused: [u8; 0],
-}
-#[repr(C)]
-#[derive(Debug)]
 pub struct crocksdb_universal_compaction_options_t {
     _unused: [u8; 0],
 }
@@ -796,11 +861,6 @@ pub struct crocksdb_envoptions_t {
 #[repr(C)]
 #[derive(Debug)]
 pub struct crocksdb_sequential_file_t {
-    _unused: [u8; 0],
-}
-#[repr(C)]
-#[derive(Debug)]
-pub struct crocksdb_ingestexternalfileoptions_t {
     _unused: [u8; 0],
 }
 #[repr(C)]
@@ -906,11 +966,6 @@ pub struct crocksdb_level_meta_data_t {
 #[repr(C)]
 #[derive(Debug)]
 pub struct crocksdb_sst_file_meta_data_t {
-    _unused: [u8; 0],
-}
-#[repr(C)]
-#[derive(Debug)]
-pub struct crocksdb_compaction_options_t {
     _unused: [u8; 0],
 }
 #[repr(C)]
@@ -1328,7 +1383,7 @@ extern "C" {
 extern "C" {
     pub fn crocksdb_put(
         db: *mut crocksdb_t,
-        options: *const crocksdb_writeoptions_t,
+        options: *const rocksdb_WriteOptions,
         key: *const libc::c_char,
         keylen: usize,
         val: *const libc::c_char,
@@ -1339,7 +1394,7 @@ extern "C" {
 extern "C" {
     pub fn crocksdb_put_cf(
         db: *mut crocksdb_t,
-        options: *const crocksdb_writeoptions_t,
+        options: *const rocksdb_WriteOptions,
         column_family: *mut crocksdb_column_family_handle_t,
         key: *const libc::c_char,
         keylen: usize,
@@ -1351,7 +1406,7 @@ extern "C" {
 extern "C" {
     pub fn crocksdb_delete(
         db: *mut crocksdb_t,
-        options: *const crocksdb_writeoptions_t,
+        options: *const rocksdb_WriteOptions,
         key: *const libc::c_char,
         keylen: usize,
         s: *mut rocksdb_Status,
@@ -1360,7 +1415,7 @@ extern "C" {
 extern "C" {
     pub fn crocksdb_delete_cf(
         db: *mut crocksdb_t,
-        options: *const crocksdb_writeoptions_t,
+        options: *const rocksdb_WriteOptions,
         column_family: *mut crocksdb_column_family_handle_t,
         key: *const libc::c_char,
         keylen: usize,
@@ -1370,7 +1425,7 @@ extern "C" {
 extern "C" {
     pub fn crocksdb_single_delete(
         db: *mut crocksdb_t,
-        options: *const crocksdb_writeoptions_t,
+        options: *const rocksdb_WriteOptions,
         key: *const libc::c_char,
         keylen: usize,
         s: *mut rocksdb_Status,
@@ -1379,7 +1434,7 @@ extern "C" {
 extern "C" {
     pub fn crocksdb_single_delete_cf(
         db: *mut crocksdb_t,
-        options: *const crocksdb_writeoptions_t,
+        options: *const rocksdb_WriteOptions,
         column_family: *mut crocksdb_column_family_handle_t,
         key: *const libc::c_char,
         keylen: usize,
@@ -1389,7 +1444,7 @@ extern "C" {
 extern "C" {
     pub fn crocksdb_delete_range_cf(
         db: *mut crocksdb_t,
-        options: *const crocksdb_writeoptions_t,
+        options: *const rocksdb_WriteOptions,
         column_family: *mut crocksdb_column_family_handle_t,
         begin_key: *const libc::c_char,
         begin_keylen: usize,
@@ -1401,7 +1456,7 @@ extern "C" {
 extern "C" {
     pub fn crocksdb_merge(
         db: *mut crocksdb_t,
-        options: *const crocksdb_writeoptions_t,
+        options: *const rocksdb_WriteOptions,
         key: *const libc::c_char,
         keylen: usize,
         val: *const libc::c_char,
@@ -1412,7 +1467,7 @@ extern "C" {
 extern "C" {
     pub fn crocksdb_merge_cf(
         db: *mut crocksdb_t,
-        options: *const crocksdb_writeoptions_t,
+        options: *const rocksdb_WriteOptions,
         column_family: *mut crocksdb_column_family_handle_t,
         key: *const libc::c_char,
         keylen: usize,
@@ -1424,7 +1479,7 @@ extern "C" {
 extern "C" {
     pub fn crocksdb_write(
         db: *mut crocksdb_t,
-        options: *const crocksdb_writeoptions_t,
+        options: *const rocksdb_WriteOptions,
         batch: *mut crocksdb_writebatch_t,
         s: *mut rocksdb_Status,
     );
@@ -1432,7 +1487,7 @@ extern "C" {
 extern "C" {
     pub fn crocksdb_write_multi_batch(
         db: *mut crocksdb_t,
-        options: *const crocksdb_writeoptions_t,
+        options: *const rocksdb_WriteOptions,
         batches: *mut *mut crocksdb_writebatch_t,
         batch_size: usize,
         s: *mut rocksdb_Status,
@@ -1441,7 +1496,7 @@ extern "C" {
 extern "C" {
     pub fn crocksdb_get(
         db: *mut crocksdb_t,
-        options: *const crocksdb_readoptions_t,
+        options: *const rocksdb_ReadOptions,
         key: *const libc::c_char,
         keylen: usize,
         vallen: *mut usize,
@@ -1451,7 +1506,7 @@ extern "C" {
 extern "C" {
     pub fn crocksdb_get_cf(
         db: *mut crocksdb_t,
-        options: *const crocksdb_readoptions_t,
+        options: *const rocksdb_ReadOptions,
         column_family: *mut crocksdb_column_family_handle_t,
         key: *const libc::c_char,
         keylen: usize,
@@ -1462,7 +1517,7 @@ extern "C" {
 extern "C" {
     pub fn crocksdb_multi_get(
         db: *mut crocksdb_t,
-        options: *const crocksdb_readoptions_t,
+        options: *const rocksdb_ReadOptions,
         num_keys: usize,
         keys_list: *const *const libc::c_char,
         keys_list_sizes: *const usize,
@@ -1474,7 +1529,7 @@ extern "C" {
 extern "C" {
     pub fn crocksdb_multi_get_cf(
         db: *mut crocksdb_t,
-        options: *const crocksdb_readoptions_t,
+        options: *const rocksdb_ReadOptions,
         column_families: *const *const crocksdb_column_family_handle_t,
         num_keys: usize,
         keys_list: *const *const libc::c_char,
@@ -1487,20 +1542,20 @@ extern "C" {
 extern "C" {
     pub fn crocksdb_create_iterator(
         db: *mut crocksdb_t,
-        options: *const crocksdb_readoptions_t,
+        options: *const rocksdb_ReadOptions,
     ) -> *mut crocksdb_iterator_t;
 }
 extern "C" {
     pub fn crocksdb_create_iterator_cf(
         db: *mut crocksdb_t,
-        options: *const crocksdb_readoptions_t,
+        options: *const rocksdb_ReadOptions,
         column_family: *mut crocksdb_column_family_handle_t,
     ) -> *mut crocksdb_iterator_t;
 }
 extern "C" {
     pub fn crocksdb_create_iterators(
         db: *mut crocksdb_t,
-        opts: *mut crocksdb_readoptions_t,
+        opts: *const rocksdb_ReadOptions,
         column_families: *mut *mut crocksdb_column_family_handle_t,
         iterators: *mut *mut crocksdb_iterator_t,
         size: usize,
@@ -1623,7 +1678,7 @@ extern "C" {
 extern "C" {
     pub fn crocksdb_compact_range_opt(
         db: *mut crocksdb_t,
-        opt: *mut crocksdb_compactoptions_t,
+        opt: *const rocksdb_CompactRangeOptions,
         start_key: *const libc::c_char,
         start_key_len: usize,
         limit_key: *const libc::c_char,
@@ -1634,7 +1689,7 @@ extern "C" {
     pub fn crocksdb_compact_range_cf_opt(
         db: *mut crocksdb_t,
         column_family: *mut crocksdb_column_family_handle_t,
-        opt: *mut crocksdb_compactoptions_t,
+        opt: *const rocksdb_CompactRangeOptions,
         start_key: *const libc::c_char,
         start_key_len: usize,
         limit_key: *const libc::c_char,
@@ -1654,7 +1709,7 @@ extern "C" {
 extern "C" {
     pub fn crocksdb_flush(
         db: *mut crocksdb_t,
-        options: *const crocksdb_flushoptions_t,
+        options: *const rocksdb_FlushOptions,
         s: *mut rocksdb_Status,
     );
 }
@@ -1662,7 +1717,7 @@ extern "C" {
     pub fn crocksdb_flush_cf(
         db: *mut crocksdb_t,
         column_family: *mut crocksdb_column_family_handle_t,
-        options: *const crocksdb_flushoptions_t,
+        options: *const rocksdb_FlushOptions,
         s: *mut rocksdb_Status,
     );
 }
@@ -1671,7 +1726,7 @@ extern "C" {
         db: *mut crocksdb_t,
         column_familys: *mut *const crocksdb_column_family_handle_t,
         num_handles: libc::c_int,
-        options: *const crocksdb_flushoptions_t,
+        options: *const rocksdb_FlushOptions,
         s: *mut rocksdb_Status,
     );
 }
@@ -3613,97 +3668,8 @@ extern "C" {
     pub fn crocksdb_mergeoperator_destroy(arg1: *mut crocksdb_mergeoperator_t);
 }
 extern "C" {
-    pub fn crocksdb_readoptions_create() -> *mut crocksdb_readoptions_t;
-}
-extern "C" {
-    pub fn crocksdb_readoptions_destroy(arg1: *mut crocksdb_readoptions_t);
-}
-extern "C" {
-    pub fn crocksdb_readoptions_set_verify_checksums(
-        arg1: *mut crocksdb_readoptions_t,
-        arg2: libc::c_uchar,
-    );
-}
-extern "C" {
-    pub fn crocksdb_readoptions_set_fill_cache(
-        arg1: *mut crocksdb_readoptions_t,
-        arg2: libc::c_uchar,
-    );
-}
-extern "C" {
-    pub fn crocksdb_readoptions_set_snapshot(
-        arg1: *mut crocksdb_readoptions_t,
-        arg2: *const crocksdb_snapshot_t,
-    );
-}
-extern "C" {
-    pub fn crocksdb_readoptions_set_iterate_lower_bound(
-        arg1: *mut crocksdb_readoptions_t,
-        key: *const libc::c_char,
-        keylen: usize,
-    );
-}
-extern "C" {
-    pub fn crocksdb_readoptions_set_iterate_upper_bound(
-        arg1: *mut crocksdb_readoptions_t,
-        key: *const libc::c_char,
-        keylen: usize,
-    );
-}
-extern "C" {
-    pub fn crocksdb_readoptions_set_read_tier(
-        arg1: *mut crocksdb_readoptions_t,
-        arg2: rocksdb_ReadTier,
-    );
-}
-extern "C" {
-    pub fn crocksdb_readoptions_set_tailing(arg1: *mut crocksdb_readoptions_t, arg2: libc::c_uchar);
-}
-extern "C" {
-    pub fn crocksdb_readoptions_set_managed(arg1: *mut crocksdb_readoptions_t, arg2: libc::c_uchar);
-}
-extern "C" {
-    pub fn crocksdb_readoptions_set_readahead_size(arg1: *mut crocksdb_readoptions_t, arg2: usize);
-}
-extern "C" {
-    pub fn crocksdb_readoptions_set_max_skippable_internal_keys(
-        arg1: *mut crocksdb_readoptions_t,
-        arg2: u64,
-    );
-}
-extern "C" {
-    pub fn crocksdb_readoptions_set_total_order_seek(
-        arg1: *mut crocksdb_readoptions_t,
-        arg2: libc::c_uchar,
-    );
-}
-extern "C" {
-    pub fn crocksdb_readoptions_set_prefix_same_as_start(
-        arg1: *mut crocksdb_readoptions_t,
-        arg2: libc::c_uchar,
-    );
-}
-extern "C" {
-    pub fn crocksdb_readoptions_set_pin_data(
-        arg1: *mut crocksdb_readoptions_t,
-        arg2: libc::c_uchar,
-    );
-}
-extern "C" {
-    pub fn crocksdb_readoptions_set_background_purge_on_iterator_cleanup(
-        arg1: *mut crocksdb_readoptions_t,
-        arg2: libc::c_uchar,
-    );
-}
-extern "C" {
-    pub fn crocksdb_readoptions_set_ignore_range_deletions(
-        arg1: *mut crocksdb_readoptions_t,
-        arg2: libc::c_uchar,
-    );
-}
-extern "C" {
     pub fn crocksdb_readoptions_set_table_filter(
-        arg1: *mut crocksdb_readoptions_t,
+        arg1: *mut rocksdb_ReadOptions,
         arg2: *mut libc::c_void,
         table_filter: ::std::option::Option<
             unsafe extern "C" fn(
@@ -3715,94 +3681,13 @@ extern "C" {
     );
 }
 extern "C" {
-    pub fn crocksdb_writeoptions_create() -> *mut crocksdb_writeoptions_t;
+    pub fn crocksdb_writeoptions_init(arg1: *mut rocksdb_WriteOptions);
 }
 extern "C" {
-    pub fn crocksdb_writeoptions_destroy(arg1: *mut crocksdb_writeoptions_t);
+    pub fn crocksdb_compactrangeoptions_init(arg1: *mut rocksdb_CompactRangeOptions);
 }
 extern "C" {
-    pub fn crocksdb_writeoptions_set_sync(arg1: *mut crocksdb_writeoptions_t, arg2: libc::c_uchar);
-}
-extern "C" {
-    pub fn crocksdb_writeoptions_disable_wal(
-        opt: *mut crocksdb_writeoptions_t,
-        disable: libc::c_int,
-    );
-}
-extern "C" {
-    pub fn crocksdb_writeoptions_set_ignore_missing_column_families(
-        arg1: *mut crocksdb_writeoptions_t,
-        arg2: libc::c_uchar,
-    );
-}
-extern "C" {
-    pub fn crocksdb_writeoptions_set_no_slowdown(
-        arg1: *mut crocksdb_writeoptions_t,
-        arg2: libc::c_uchar,
-    );
-}
-extern "C" {
-    pub fn crocksdb_writeoptions_set_low_pri(
-        arg1: *mut crocksdb_writeoptions_t,
-        arg2: libc::c_uchar,
-    );
-}
-extern "C" {
-    pub fn crocksdb_compactoptions_create() -> *mut crocksdb_compactoptions_t;
-}
-extern "C" {
-    pub fn crocksdb_compactoptions_destroy(arg1: *mut crocksdb_compactoptions_t);
-}
-extern "C" {
-    pub fn crocksdb_compactoptions_set_exclusive_manual_compaction(
-        arg1: *mut crocksdb_compactoptions_t,
-        arg2: libc::c_uchar,
-    );
-}
-extern "C" {
-    pub fn crocksdb_compactoptions_set_change_level(
-        arg1: *mut crocksdb_compactoptions_t,
-        arg2: libc::c_uchar,
-    );
-}
-extern "C" {
-    pub fn crocksdb_compactoptions_set_target_level(
-        arg1: *mut crocksdb_compactoptions_t,
-        arg2: libc::c_int,
-    );
-}
-extern "C" {
-    pub fn crocksdb_compactoptions_set_target_path_id(
-        arg1: *mut crocksdb_compactoptions_t,
-        arg2: libc::c_int,
-    );
-}
-extern "C" {
-    pub fn crocksdb_compactoptions_set_max_subcompactions(
-        arg1: *mut crocksdb_compactoptions_t,
-        arg2: libc::c_int,
-    );
-}
-extern "C" {
-    pub fn crocksdb_compactoptions_set_bottommost_level_compaction(
-        arg1: *mut crocksdb_compactoptions_t,
-        arg2: rocksdb_BottommostLevelCompaction,
-    );
-}
-extern "C" {
-    pub fn crocksdb_flushoptions_create() -> *mut crocksdb_flushoptions_t;
-}
-extern "C" {
-    pub fn crocksdb_flushoptions_destroy(arg1: *mut crocksdb_flushoptions_t);
-}
-extern "C" {
-    pub fn crocksdb_flushoptions_set_wait(arg1: *mut crocksdb_flushoptions_t, arg2: libc::c_uchar);
-}
-extern "C" {
-    pub fn crocksdb_flushoptions_set_allow_write_stall(
-        arg1: *mut crocksdb_flushoptions_t,
-        arg2: libc::c_uchar,
-    );
+    pub fn crocksdb_flushoptions_init(arg1: *mut rocksdb_FlushOptions);
 }
 extern "C" {
     pub fn crocksdb_jemalloc_nodump_allocator_create(
@@ -4107,7 +3992,7 @@ extern "C" {
 extern "C" {
     pub fn crocksdb_sstfilereader_new_iterator(
         reader: *mut crocksdb_sstfilereader_t,
-        options: *const crocksdb_readoptions_t,
+        options: *const rocksdb_ReadOptions,
     ) -> *mut crocksdb_iterator_t;
 }
 extern "C" {
@@ -4238,54 +4123,14 @@ extern "C" {
     ) -> u64;
 }
 extern "C" {
-    pub fn crocksdb_ingestexternalfileoptions_create() -> *mut crocksdb_ingestexternalfileoptions_t;
-}
-extern "C" {
-    pub fn crocksdb_ingestexternalfileoptions_set_move_files(
-        opt: *mut crocksdb_ingestexternalfileoptions_t,
-        move_files: libc::c_uchar,
-    );
-}
-extern "C" {
-    pub fn crocksdb_ingestexternalfileoptions_set_snapshot_consistency(
-        opt: *mut crocksdb_ingestexternalfileoptions_t,
-        snapshot_consistency: libc::c_uchar,
-    );
-}
-extern "C" {
-    pub fn crocksdb_ingestexternalfileoptions_set_allow_global_seqno(
-        opt: *mut crocksdb_ingestexternalfileoptions_t,
-        allow_global_seqno: libc::c_uchar,
-    );
-}
-extern "C" {
-    pub fn crocksdb_ingestexternalfileoptions_set_allow_blocking_flush(
-        opt: *mut crocksdb_ingestexternalfileoptions_t,
-        allow_blocking_flush: libc::c_uchar,
-    );
-}
-extern "C" {
-    pub fn crocksdb_ingestexternalfileoptions_get_write_global_seqno(
-        opt: *const crocksdb_ingestexternalfileoptions_t,
-    ) -> libc::c_uchar;
-}
-extern "C" {
-    pub fn crocksdb_ingestexternalfileoptions_set_write_global_seqno(
-        opt: *mut crocksdb_ingestexternalfileoptions_t,
-        write_global_seqno: libc::c_uchar,
-    );
-}
-extern "C" {
-    pub fn crocksdb_ingestexternalfileoptions_destroy(
-        opt: *mut crocksdb_ingestexternalfileoptions_t,
-    );
+    pub fn crocksdb_ingestexternalfileoptions_init(arg1: *mut rocksdb_IngestExternalFileOptions);
 }
 extern "C" {
     pub fn crocksdb_ingest_external_file(
         db: *mut crocksdb_t,
         file_list: *const *const libc::c_char,
         list_len: usize,
-        opt: *const crocksdb_ingestexternalfileoptions_t,
+        opt: *const rocksdb_IngestExternalFileOptions,
         s: *mut rocksdb_Status,
     );
 }
@@ -4295,7 +4140,7 @@ extern "C" {
         handle: *mut crocksdb_column_family_handle_t,
         file_list: *const *const libc::c_char,
         list_len: usize,
-        opt: *const crocksdb_ingestexternalfileoptions_t,
+        opt: *const rocksdb_IngestExternalFileOptions,
         s: *mut rocksdb_Status,
     );
 }
@@ -4305,7 +4150,7 @@ extern "C" {
         handle: *mut crocksdb_column_family_handle_t,
         file_list: *const *const libc::c_char,
         list_len: usize,
-        opt: *const crocksdb_ingestexternalfileoptions_t,
+        opt: *const rocksdb_IngestExternalFileOptions,
         s: *mut rocksdb_Status,
     ) -> libc::c_uchar;
 }
@@ -4517,7 +4362,7 @@ extern "C" {
 extern "C" {
     pub fn crocksdb_get_pinned(
         db: *mut crocksdb_t,
-        options: *const crocksdb_readoptions_t,
+        options: *const rocksdb_ReadOptions,
         key: *const libc::c_char,
         keylen: usize,
         s: *mut rocksdb_Status,
@@ -4526,7 +4371,7 @@ extern "C" {
 extern "C" {
     pub fn crocksdb_get_pinned_cf(
         db: *mut crocksdb_t,
-        options: *const crocksdb_readoptions_t,
+        options: *const rocksdb_ReadOptions,
         column_family: *mut crocksdb_column_family_handle_t,
         key: *const libc::c_char,
         keylen: usize,
@@ -4851,34 +4696,13 @@ extern "C" {
     ) -> *const libc::c_char;
 }
 extern "C" {
-    pub fn crocksdb_compaction_options_create() -> *mut crocksdb_compaction_options_t;
-}
-extern "C" {
-    pub fn crocksdb_compaction_options_destroy(arg1: *mut crocksdb_compaction_options_t);
-}
-extern "C" {
-    pub fn crocksdb_compaction_options_set_compression(
-        arg1: *mut crocksdb_compaction_options_t,
-        arg2: rocksdb_CompressionType,
-    );
-}
-extern "C" {
-    pub fn crocksdb_compaction_options_set_output_file_size_limit(
-        arg1: *mut crocksdb_compaction_options_t,
-        arg2: usize,
-    );
-}
-extern "C" {
-    pub fn crocksdb_compaction_options_set_max_subcompactions(
-        arg1: *mut crocksdb_compaction_options_t,
-        arg2: libc::c_int,
-    );
+    pub fn crocksdb_compaction_options_init(arg1: *mut rocksdb_CompactionOptions);
 }
 extern "C" {
     pub fn crocksdb_compact_files_cf(
         arg1: *mut crocksdb_t,
         arg2: *mut crocksdb_column_family_handle_t,
-        arg3: *mut crocksdb_compaction_options_t,
+        arg3: *const rocksdb_CompactionOptions,
         input_file_names: *mut *const libc::c_char,
         input_file_count: usize,
         output_level: libc::c_int,
@@ -5433,11 +5257,6 @@ pub struct ctitandb_blob_index_t {
 pub struct ctitandb_options_t {
     _unused: [u8; 0],
 }
-#[repr(C)]
-#[derive(Debug)]
-pub struct ctitandb_readoptions_t {
-    _unused: [u8; 0],
-}
 extern "C" {
     pub fn ctitandb_open_column_families(
         name: *const libc::c_char,
@@ -5622,37 +5441,25 @@ extern "C" {
     );
 }
 extern "C" {
-    pub fn ctitandb_readoptions_create() -> *mut ctitandb_readoptions_t;
-}
-extern "C" {
-    pub fn ctitandb_readoptions_destroy(opts: *mut ctitandb_readoptions_t);
-}
-extern "C" {
-    pub fn ctitandb_readoptions_key_only(opts: *mut ctitandb_readoptions_t) -> libc::c_uchar;
-}
-extern "C" {
-    pub fn ctitandb_readoptions_set_key_only(opts: *mut ctitandb_readoptions_t, v: libc::c_uchar);
+    pub fn ctitandb_readoptions_init(arg1: *mut rocksdb_titandb_TitanReadOptions);
 }
 extern "C" {
     pub fn ctitandb_create_iterator(
         db: *mut crocksdb_t,
-        options: *const crocksdb_readoptions_t,
-        titan_options: *const ctitandb_readoptions_t,
+        titan_options: *const rocksdb_titandb_TitanReadOptions,
     ) -> *mut crocksdb_iterator_t;
 }
 extern "C" {
     pub fn ctitandb_create_iterator_cf(
         db: *mut crocksdb_t,
-        options: *const crocksdb_readoptions_t,
-        titan_options: *const ctitandb_readoptions_t,
+        titan_options: *const rocksdb_titandb_TitanReadOptions,
         column_family: *mut crocksdb_column_family_handle_t,
     ) -> *mut crocksdb_iterator_t;
 }
 extern "C" {
     pub fn ctitandb_create_iterators(
         db: *mut crocksdb_t,
-        options: *mut crocksdb_readoptions_t,
-        titan_options: *mut ctitandb_readoptions_t,
+        titan_options: *const rocksdb_titandb_TitanReadOptions,
         column_families: *mut *mut crocksdb_column_family_handle_t,
         iterators: *mut *mut crocksdb_iterator_t,
         size: usize,

--- a/tirocks-sys/bindings/bindings.rs
+++ b/tirocks-sys/bindings/bindings.rs
@@ -119,11 +119,6 @@ pub enum rocksdb_TableFileCreationReason {
     kRecovery = 2,
     kMisc = 3,
 }
-#[repr(C)]
-#[repr(align(8))]
-pub struct rocksdb_TableProperties {
-    pub _bindgen_opaque_blob: [u64; 53usize],
-}
 #[repr(i32)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub enum rocksdb_BackgroundErrorReason {

--- a/tirocks-sys/build.rs
+++ b/tirocks-sys/build.rs
@@ -42,10 +42,13 @@ fn bindgen_rocksdb(file_path: &Path) {
         .allowlist_type(r"\brocksdb::titandb::TickerType")
         .allowlist_type(r"\brocksdb::titandb::HistogramType")
         .opaque_type(r"\brocksdb::Env")
+        // Just blocking the type will still include its dependencies.
         .opaque_type(r"\brocksdb::TableProperties")
         // Block all system headers
         .blocklist_file(r"^/.*")
         .blocklist_type(r"\brocksdb::Env_FileAttributes")
+        // `TableProperties` has different size on different platform.
+        .blocklist_type(r"\brocksdb::TableProperties")
         .with_codegen_config(
             bindgen::CodegenConfig::FUNCTIONS
                 | bindgen::CodegenConfig::VARS

--- a/tirocks-sys/build.rs
+++ b/tirocks-sys/build.rs
@@ -42,6 +42,7 @@ fn bindgen_rocksdb(file_path: &Path) {
         .allowlist_type(r"\brocksdb::titandb::TickerType")
         .allowlist_type(r"\brocksdb::titandb::HistogramType")
         .opaque_type(r"\brocksdb::Env")
+        .opaque_type(r"\brocksdb::TableProperties")
         // Block all system headers
         .blocklist_file(r"^/.*")
         .blocklist_type(r"\brocksdb::Env_FileAttributes")

--- a/tirocks-sys/crocksdb/c.cc
+++ b/tirocks-sys/crocksdb/c.cc
@@ -228,28 +228,14 @@ struct crocksdb_writebatch_t {
 struct crocksdb_snapshot_t {
   const Snapshot* rep;
 };
-struct crocksdb_flushoptions_t {
-  FlushOptions rep;
-};
 struct crocksdb_fifo_compaction_options_t {
   CompactionOptionsFIFO rep;
-};
-struct crocksdb_readoptions_t {
-  ReadOptions rep;
-  Slice upper_bound;  // stack variable to set pointer to in ReadOptions
-  Slice lower_bound;
-};
-struct crocksdb_writeoptions_t {
-  WriteOptions rep;
 };
 struct crocksdb_options_t {
   Options rep;
 };
 struct crocksdb_column_family_descriptor {
   ColumnFamilyDescriptor rep;
-};
-struct crocksdb_compactoptions_t {
-  CompactRangeOptions rep;
 };
 struct crocksdb_block_based_table_options_t {
   BlockBasedTableOptions rep;
@@ -332,9 +318,6 @@ struct crocksdb_envoptions_t {
 struct crocksdb_sequential_file_t {
   SequentialFile* rep;
 };
-struct crocksdb_ingestexternalfileoptions_t {
-  IngestExternalFileOptions rep;
-};
 struct crocksdb_sstfilereader_t {
   SstFileReader* rep;
 };
@@ -388,9 +371,6 @@ struct crocksdb_level_meta_data_t {
 };
 struct crocksdb_sst_file_meta_data_t {
   SstFileMetaData rep;
-};
-struct crocksdb_compaction_options_t {
-  CompactionOptions rep;
 };
 
 const Slice crocksdb_property_name_num_files_at_level_prefix =
@@ -1082,90 +1062,84 @@ void crocksdb_column_family_handle_destroy(
   delete handle;
 }
 
-void crocksdb_put(crocksdb_t* db, const crocksdb_writeoptions_t* options,
-                  const char* key, size_t keylen, const char* val,
-                  size_t vallen, Status* s) {
-  *s = db->rep->Put(options->rep, Slice(key, keylen), Slice(val, vallen));
+void crocksdb_put(crocksdb_t* db, const WriteOptions* options, const char* key,
+                  size_t keylen, const char* val, size_t vallen, Status* s) {
+  *s = db->rep->Put(*options, Slice(key, keylen), Slice(val, vallen));
 }
 
-void crocksdb_put_cf(crocksdb_t* db, const crocksdb_writeoptions_t* options,
+void crocksdb_put_cf(crocksdb_t* db, const WriteOptions* options,
                      crocksdb_column_family_handle_t* column_family,
                      const char* key, size_t keylen, const char* val,
                      size_t vallen, Status* s) {
-  *s = db->rep->Put(options->rep, column_family->rep, Slice(key, keylen),
+  *s = db->rep->Put(*options, column_family->rep, Slice(key, keylen),
                     Slice(val, vallen));
 }
 
-void crocksdb_delete(crocksdb_t* db, const crocksdb_writeoptions_t* options,
+void crocksdb_delete(crocksdb_t* db, const WriteOptions* options,
                      const char* key, size_t keylen, Status* s) {
-  *s = db->rep->Delete(options->rep, Slice(key, keylen));
+  *s = db->rep->Delete(*options, Slice(key, keylen));
 }
 
-void crocksdb_delete_cf(crocksdb_t* db, const crocksdb_writeoptions_t* options,
+void crocksdb_delete_cf(crocksdb_t* db, const WriteOptions* options,
                         crocksdb_column_family_handle_t* column_family,
                         const char* key, size_t keylen, Status* s) {
-  *s = db->rep->Delete(options->rep, column_family->rep, Slice(key, keylen));
+  *s = db->rep->Delete(*options, column_family->rep, Slice(key, keylen));
 }
 
-void crocksdb_single_delete(crocksdb_t* db,
-                            const crocksdb_writeoptions_t* options,
+void crocksdb_single_delete(crocksdb_t* db, const WriteOptions* options,
                             const char* key, size_t keylen, Status* s) {
-  *s = db->rep->SingleDelete(options->rep, Slice(key, keylen));
+  *s = db->rep->SingleDelete(*options, Slice(key, keylen));
 }
 
-void crocksdb_single_delete_cf(crocksdb_t* db,
-                               const crocksdb_writeoptions_t* options,
+void crocksdb_single_delete_cf(crocksdb_t* db, const WriteOptions* options,
                                crocksdb_column_family_handle_t* column_family,
                                const char* key, size_t keylen, Status* s) {
-  *s = db->rep->SingleDelete(options->rep, column_family->rep,
-                             Slice(key, keylen));
+  *s = db->rep->SingleDelete(*options, column_family->rep, Slice(key, keylen));
 }
 
-void crocksdb_delete_range_cf(crocksdb_t* db,
-                              const crocksdb_writeoptions_t* options,
+void crocksdb_delete_range_cf(crocksdb_t* db, const WriteOptions* options,
                               crocksdb_column_family_handle_t* column_family,
                               const char* begin_key, size_t begin_keylen,
                               const char* end_key, size_t end_keylen,
                               Status* s) {
-  *s = db->rep->DeleteRange(options->rep, column_family->rep,
+  *s = db->rep->DeleteRange(*options, column_family->rep,
                             Slice(begin_key, begin_keylen),
                             Slice(end_key, end_keylen));
 }
 
-void crocksdb_merge(crocksdb_t* db, const crocksdb_writeoptions_t* options,
+void crocksdb_merge(crocksdb_t* db, const WriteOptions* options,
                     const char* key, size_t keylen, const char* val,
                     size_t vallen, Status* s) {
-  *s = db->rep->Merge(options->rep, Slice(key, keylen), Slice(val, vallen));
+  *s = db->rep->Merge(*options, Slice(key, keylen), Slice(val, vallen));
 }
 
-void crocksdb_merge_cf(crocksdb_t* db, const crocksdb_writeoptions_t* options,
+void crocksdb_merge_cf(crocksdb_t* db, const WriteOptions* options,
                        crocksdb_column_family_handle_t* column_family,
                        const char* key, size_t keylen, const char* val,
                        size_t vallen, Status* s) {
-  *s = db->rep->Merge(options->rep, column_family->rep, Slice(key, keylen),
+  *s = db->rep->Merge(*options, column_family->rep, Slice(key, keylen),
                       Slice(val, vallen));
 }
 
-void crocksdb_write(crocksdb_t* db, const crocksdb_writeoptions_t* options,
+void crocksdb_write(crocksdb_t* db, const WriteOptions* options,
                     crocksdb_writebatch_t* batch, Status* s) {
-  *s = db->rep->Write(options->rep, &batch->rep);
+  *s = db->rep->Write(*options, &batch->rep);
 }
 
-void crocksdb_write_multi_batch(crocksdb_t* db,
-                                const crocksdb_writeoptions_t* options,
+void crocksdb_write_multi_batch(crocksdb_t* db, const WriteOptions* options,
                                 crocksdb_writebatch_t** batches,
                                 size_t batch_size, Status* s) {
   std::vector<WriteBatch*> ws;
   for (size_t i = 0; i < batch_size; i++) {
     ws.push_back(&batches[i]->rep);
   }
-  *s = db->rep->MultiBatchWrite(options->rep, std::move(ws));
+  *s = db->rep->MultiBatchWrite(*options, std::move(ws));
 }
 
-char* crocksdb_get(crocksdb_t* db, const crocksdb_readoptions_t* options,
-                   const char* key, size_t keylen, size_t* vallen, Status* s) {
+char* crocksdb_get(crocksdb_t* db, const ReadOptions* options, const char* key,
+                   size_t keylen, size_t* vallen, Status* s) {
   std::string tmp;
-  *s = db->rep->Get(options->rep, Slice(key, keylen), &tmp);
+  *s = db->rep->Get(*options, Slice(key, keylen), &tmp);
   if (s->ok()) {
     *vallen = tmp.size();
     return CopyString(tmp);
@@ -1173,12 +1147,12 @@ char* crocksdb_get(crocksdb_t* db, const crocksdb_readoptions_t* options,
   return nullptr;
 }
 
-char* crocksdb_get_cf(crocksdb_t* db, const crocksdb_readoptions_t* options,
+char* crocksdb_get_cf(crocksdb_t* db, const ReadOptions* options,
                       crocksdb_column_family_handle_t* column_family,
                       const char* key, size_t keylen, size_t* vallen,
                       Status* s) {
   std::string tmp;
-  *s = db->rep->Get(options->rep, column_family->rep, Slice(key, keylen), &tmp);
+  *s = db->rep->Get(*options, column_family->rep, Slice(key, keylen), &tmp);
   if (s->ok()) {
     *vallen = tmp.size();
     return CopyString(tmp);
@@ -1186,7 +1160,7 @@ char* crocksdb_get_cf(crocksdb_t* db, const crocksdb_readoptions_t* options,
   return nullptr;
 }
 
-void crocksdb_multi_get(crocksdb_t* db, const crocksdb_readoptions_t* options,
+void crocksdb_multi_get(crocksdb_t* db, const ReadOptions* options,
                         size_t num_keys, const char* const* keys_list,
                         const size_t* keys_list_sizes, char** values_list,
                         size_t* values_list_sizes, Status* status_list) {
@@ -1195,7 +1169,7 @@ void crocksdb_multi_get(crocksdb_t* db, const crocksdb_readoptions_t* options,
     keys[i] = Slice(keys_list[i], keys_list_sizes[i]);
   }
   std::vector<std::string> values(num_keys);
-  std::vector<Status> statuses = db->rep->MultiGet(options->rep, keys, &values);
+  std::vector<Status> statuses = db->rep->MultiGet(*options, keys, &values);
   for (size_t i = 0; i < num_keys; i++) {
     status_list[i] = statuses[i];
     if (status_list[i].ok()) {
@@ -1206,7 +1180,7 @@ void crocksdb_multi_get(crocksdb_t* db, const crocksdb_readoptions_t* options,
 }
 
 void crocksdb_multi_get_cf(
-    crocksdb_t* db, const crocksdb_readoptions_t* options,
+    crocksdb_t* db, const ReadOptions* options,
     const crocksdb_column_family_handle_t* const* column_families,
     size_t num_keys, const char* const* keys_list,
     const size_t* keys_list_sizes, char** values_list,
@@ -1219,7 +1193,7 @@ void crocksdb_multi_get_cf(
   }
   std::vector<std::string> values(num_keys);
   std::vector<Status> statuses =
-      db->rep->MultiGet(options->rep, cfs, keys, &values);
+      db->rep->MultiGet(*options, cfs, keys, &values);
   for (size_t i = 0; i < num_keys; i++) {
     status_list[i] = statuses[i];
     if (status_list[i].ok()) {
@@ -1229,23 +1203,23 @@ void crocksdb_multi_get_cf(
   }
 }
 
-crocksdb_iterator_t* crocksdb_create_iterator(
-    crocksdb_t* db, const crocksdb_readoptions_t* options) {
+crocksdb_iterator_t* crocksdb_create_iterator(crocksdb_t* db,
+                                              const ReadOptions* options) {
   crocksdb_iterator_t* result = new crocksdb_iterator_t;
-  result->rep = db->rep->NewIterator(options->rep);
+  result->rep = db->rep->NewIterator(*options);
   return result;
 }
 
 crocksdb_iterator_t* crocksdb_create_iterator_cf(
-    crocksdb_t* db, const crocksdb_readoptions_t* options,
+    crocksdb_t* db, const ReadOptions* options,
     crocksdb_column_family_handle_t* column_family) {
   crocksdb_iterator_t* result = new crocksdb_iterator_t;
-  result->rep = db->rep->NewIterator(options->rep, column_family->rep);
+  result->rep = db->rep->NewIterator(*options, column_family->rep);
   return result;
 }
 
 void crocksdb_create_iterators(
-    crocksdb_t* db, crocksdb_readoptions_t* opts,
+    crocksdb_t* db, const ReadOptions* opts,
     crocksdb_column_family_handle_t** column_families,
     crocksdb_iterator_t** iterators, size_t size, Status* s) {
   std::vector<ColumnFamilyHandle*> column_families_vec(size);
@@ -1254,7 +1228,7 @@ void crocksdb_create_iterators(
   }
 
   std::vector<Iterator*> res;
-  *s = db->rep->NewIterators(opts->rep, column_families_vec, &res);
+  *s = db->rep->NewIterators(*opts, column_families_vec, &res);
   if (!s->ok()) {
     for (size_t i = 0; i < res.size(); i++) {
       delete res[i];
@@ -1427,12 +1401,12 @@ void crocksdb_compact_range_cf(crocksdb_t* db,
       (limit_key ? (b = Slice(limit_key, limit_key_len), &b) : nullptr));
 }
 
-void crocksdb_compact_range_opt(crocksdb_t* db, crocksdb_compactoptions_t* opt,
+void crocksdb_compact_range_opt(crocksdb_t* db, const CompactRangeOptions* opt,
                                 const char* start_key, size_t start_key_len,
                                 const char* limit_key, size_t limit_key_len) {
   Slice a, b;
   db->rep->CompactRange(
-      opt->rep,
+      *opt,
       // Pass nullptr Slice if corresponding "const char*" is nullptr
       (start_key ? (a = Slice(start_key, start_key_len), &a) : nullptr),
       (limit_key ? (b = Slice(limit_key, limit_key_len), &b) : nullptr));
@@ -1440,36 +1414,35 @@ void crocksdb_compact_range_opt(crocksdb_t* db, crocksdb_compactoptions_t* opt,
 
 void crocksdb_compact_range_cf_opt(
     crocksdb_t* db, crocksdb_column_family_handle_t* column_family,
-    crocksdb_compactoptions_t* opt, const char* start_key, size_t start_key_len,
+    const CompactRangeOptions* opt, const char* start_key, size_t start_key_len,
     const char* limit_key, size_t limit_key_len) {
   Slice a, b;
   db->rep->CompactRange(
-      opt->rep, column_family->rep,
+      *opt, column_family->rep,
       // Pass nullptr Slice if corresponding "const char*" is nullptr
       (start_key ? (a = Slice(start_key, start_key_len), &a) : nullptr),
       (limit_key ? (b = Slice(limit_key, limit_key_len), &b) : nullptr));
 }
 
-void crocksdb_flush(crocksdb_t* db, const crocksdb_flushoptions_t* options,
-                    Status* s) {
-  *s = db->rep->Flush(options->rep);
+void crocksdb_flush(crocksdb_t* db, const FlushOptions* options, Status* s) {
+  *s = db->rep->Flush(*options);
 }
 
 void crocksdb_flush_cf(crocksdb_t* db,
                        crocksdb_column_family_handle_t* column_family,
-                       const crocksdb_flushoptions_t* options, Status* s) {
-  *s = db->rep->Flush(options->rep, column_family->rep);
+                       const FlushOptions* options, Status* s) {
+  *s = db->rep->Flush(*options, column_family->rep);
 }
 
 void crocksdb_flush_cfs(crocksdb_t* db,
                         const crocksdb_column_family_handle_t** column_familys,
-                        int num_handles, const crocksdb_flushoptions_t* options,
+                        int num_handles, const FlushOptions* options,
                         Status* s) {
   std::vector<rocksdb::ColumnFamilyHandle*> handles(num_handles);
   for (int i = 0; i < num_handles; i++) {
     handles[i] = column_familys[i]->rep;
   }
-  *s = db->rep->Flush(options->rep, handles);
+  *s = db->rep->Flush(*options, handles);
 }
 
 void crocksdb_flush_wal(crocksdb_t* db, unsigned char sync, Status* s) {
@@ -3638,101 +3611,6 @@ void crocksdb_mergeoperator_destroy(crocksdb_mergeoperator_t* merge_operator) {
   delete merge_operator;
 }
 
-crocksdb_readoptions_t* crocksdb_readoptions_create() {
-  return new crocksdb_readoptions_t;
-}
-
-void crocksdb_readoptions_destroy(crocksdb_readoptions_t* opt) { delete opt; }
-
-void crocksdb_readoptions_set_verify_checksums(crocksdb_readoptions_t* opt,
-                                               unsigned char v) {
-  opt->rep.verify_checksums = v;
-}
-
-void crocksdb_readoptions_set_fill_cache(crocksdb_readoptions_t* opt,
-                                         unsigned char v) {
-  opt->rep.fill_cache = v;
-}
-
-void crocksdb_readoptions_set_snapshot(crocksdb_readoptions_t* opt,
-                                       const crocksdb_snapshot_t* snap) {
-  opt->rep.snapshot = (snap ? snap->rep : nullptr);
-}
-
-void crocksdb_readoptions_set_iterate_lower_bound(crocksdb_readoptions_t* opt,
-                                                  const char* key,
-                                                  size_t keylen) {
-  if (key == nullptr) {
-    opt->lower_bound = Slice();
-    opt->rep.iterate_lower_bound = nullptr;
-  } else {
-    opt->lower_bound = Slice(key, keylen);
-    opt->rep.iterate_lower_bound = &opt->lower_bound;
-  }
-}
-
-void crocksdb_readoptions_set_iterate_upper_bound(crocksdb_readoptions_t* opt,
-                                                  const char* key,
-                                                  size_t keylen) {
-  if (key == nullptr) {
-    opt->upper_bound = Slice();
-    opt->rep.iterate_upper_bound = nullptr;
-  } else {
-    opt->upper_bound = Slice(key, keylen);
-    opt->rep.iterate_upper_bound = &opt->upper_bound;
-  }
-}
-
-void crocksdb_readoptions_set_read_tier(crocksdb_readoptions_t* opt,
-                                        ReadTier v) {
-  opt->rep.read_tier = v;
-}
-
-void crocksdb_readoptions_set_tailing(crocksdb_readoptions_t* opt,
-                                      unsigned char v) {
-  opt->rep.tailing = v;
-}
-
-void crocksdb_readoptions_set_managed(crocksdb_readoptions_t* opt,
-                                      unsigned char v) {
-  opt->rep.managed = v;
-}
-
-void crocksdb_readoptions_set_readahead_size(crocksdb_readoptions_t* opt,
-                                             size_t v) {
-  opt->rep.readahead_size = v;
-}
-
-void crocksdb_readoptions_set_max_skippable_internal_keys(
-    crocksdb_readoptions_t* opt, uint64_t n) {
-  opt->rep.max_skippable_internal_keys = n;
-}
-
-void crocksdb_readoptions_set_total_order_seek(crocksdb_readoptions_t* opt,
-                                               unsigned char v) {
-  opt->rep.total_order_seek = v;
-}
-
-void crocksdb_readoptions_set_prefix_same_as_start(crocksdb_readoptions_t* opt,
-                                                   unsigned char v) {
-  opt->rep.prefix_same_as_start = v;
-}
-
-void crocksdb_readoptions_set_pin_data(crocksdb_readoptions_t* opt,
-                                       unsigned char v) {
-  opt->rep.pin_data = v;
-}
-
-void crocksdb_readoptions_set_background_purge_on_iterator_cleanup(
-    crocksdb_readoptions_t* opt, unsigned char v) {
-  opt->rep.background_purge_on_iterator_cleanup = v;
-}
-
-void crocksdb_readoptions_set_ignore_range_deletions(
-    crocksdb_readoptions_t* opt, unsigned char v) {
-  opt->rep.ignore_range_deletions = v;
-}
-
 struct TableFilterCtx {
   TableFilterCtx(void* ctx, void (*destroy)(void*))
       : ctx_(ctx), destroy_(destroy) {}
@@ -3770,96 +3648,19 @@ struct TableFilter {
 };
 
 void crocksdb_readoptions_set_table_filter(
-    crocksdb_readoptions_t* opt, void* ctx,
+    ReadOptions* opt, void* ctx,
     unsigned char (*table_filter)(void*, const crocksdb_table_properties_t*),
     void (*destroy)(void*)) {
-  opt->rep.table_filter = TableFilter(ctx, table_filter, destroy);
+  opt->table_filter = TableFilter(ctx, table_filter, destroy);
 }
 
-crocksdb_writeoptions_t* crocksdb_writeoptions_create() {
-  return new crocksdb_writeoptions_t;
+void crocksdb_writeoptions_init(WriteOptions* opt) { *opt = WriteOptions(); }
+
+void crocksdb_compactrangeoptions_init(CompactRangeOptions* opt) {
+  *opt = CompactRangeOptions();
 }
 
-void crocksdb_writeoptions_destroy(crocksdb_writeoptions_t* opt) { delete opt; }
-
-void crocksdb_writeoptions_set_sync(crocksdb_writeoptions_t* opt,
-                                    unsigned char v) {
-  opt->rep.sync = v;
-}
-
-void crocksdb_writeoptions_disable_wal(crocksdb_writeoptions_t* opt,
-                                       int disable) {
-  opt->rep.disableWAL = disable;
-}
-
-void crocksdb_writeoptions_set_ignore_missing_column_families(
-    crocksdb_writeoptions_t* opt, unsigned char v) {
-  opt->rep.ignore_missing_column_families = v;
-}
-
-void crocksdb_writeoptions_set_no_slowdown(crocksdb_writeoptions_t* opt,
-                                           unsigned char v) {
-  opt->rep.no_slowdown = v;
-}
-
-void crocksdb_writeoptions_set_low_pri(crocksdb_writeoptions_t* opt,
-                                       unsigned char v) {
-  opt->rep.low_pri = v;
-}
-
-crocksdb_compactoptions_t* crocksdb_compactoptions_create() {
-  return new crocksdb_compactoptions_t;
-}
-
-void crocksdb_compactoptions_destroy(crocksdb_compactoptions_t* opt) {
-  delete opt;
-}
-
-void crocksdb_compactoptions_set_exclusive_manual_compaction(
-    crocksdb_compactoptions_t* opt, unsigned char v) {
-  opt->rep.exclusive_manual_compaction = v;
-}
-
-void crocksdb_compactoptions_set_change_level(crocksdb_compactoptions_t* opt,
-                                              unsigned char v) {
-  opt->rep.change_level = v;
-}
-
-void crocksdb_compactoptions_set_target_level(crocksdb_compactoptions_t* opt,
-                                              int n) {
-  opt->rep.target_level = n;
-}
-
-void crocksdb_compactoptions_set_target_path_id(crocksdb_compactoptions_t* opt,
-                                                int n) {
-  opt->rep.target_path_id = n;
-}
-
-void crocksdb_compactoptions_set_max_subcompactions(
-    crocksdb_compactoptions_t* opt, int v) {
-  opt->rep.max_subcompactions = v;
-}
-
-void crocksdb_compactoptions_set_bottommost_level_compaction(
-    crocksdb_compactoptions_t* opt, BottommostLevelCompaction v) {
-  opt->rep.bottommost_level_compaction = v;
-}
-
-crocksdb_flushoptions_t* crocksdb_flushoptions_create() {
-  return new crocksdb_flushoptions_t;
-}
-
-void crocksdb_flushoptions_destroy(crocksdb_flushoptions_t* opt) { delete opt; }
-
-void crocksdb_flushoptions_set_wait(crocksdb_flushoptions_t* opt,
-                                    unsigned char v) {
-  opt->rep.wait = v;
-}
-
-void crocksdb_flushoptions_set_allow_write_stall(crocksdb_flushoptions_t* opt,
-                                                 unsigned char v) {
-  opt->rep.allow_write_stall = v;
-}
+void crocksdb_flushoptions_init(FlushOptions* opt) { *opt = FlushOptions(); }
 
 crocksdb_memory_allocator_t* crocksdb_jemalloc_nodump_allocator_create(
     Status* s) {
@@ -4251,9 +4052,9 @@ void crocksdb_sstfilereader_open(crocksdb_sstfilereader_t* reader,
 }
 
 crocksdb_iterator_t* crocksdb_sstfilereader_new_iterator(
-    crocksdb_sstfilereader_t* reader, const crocksdb_readoptions_t* options) {
+    crocksdb_sstfilereader_t* reader, const ReadOptions* options) {
   auto it = new crocksdb_iterator_t;
-  it->rep = reader->rep->NewIterator(options->rep);
+  it->rep = reader->rep->NewIterator(*options);
   return it;
 }
 
@@ -4378,77 +4179,38 @@ uint64_t crocksdb_externalsstfileinfo_num_entries(
   return info->rep.num_entries;
 }
 
-crocksdb_ingestexternalfileoptions_t*
-crocksdb_ingestexternalfileoptions_create() {
-  crocksdb_ingestexternalfileoptions_t* opt =
-      new crocksdb_ingestexternalfileoptions_t;
-  return opt;
+void crocksdb_ingestexternalfileoptions_init(IngestExternalFileOptions* opt) {
+  *opt = IngestExternalFileOptions();
 }
 
-void crocksdb_ingestexternalfileoptions_set_move_files(
-    crocksdb_ingestexternalfileoptions_t* opt, unsigned char move_files) {
-  opt->rep.move_files = move_files;
-}
-
-void crocksdb_ingestexternalfileoptions_set_snapshot_consistency(
-    crocksdb_ingestexternalfileoptions_t* opt,
-    unsigned char snapshot_consistency) {
-  opt->rep.snapshot_consistency = snapshot_consistency;
-}
-
-void crocksdb_ingestexternalfileoptions_set_allow_global_seqno(
-    crocksdb_ingestexternalfileoptions_t* opt,
-    unsigned char allow_global_seqno) {
-  opt->rep.allow_global_seqno = allow_global_seqno;
-}
-
-void crocksdb_ingestexternalfileoptions_set_allow_blocking_flush(
-    crocksdb_ingestexternalfileoptions_t* opt,
-    unsigned char allow_blocking_flush) {
-  opt->rep.allow_blocking_flush = allow_blocking_flush;
-}
-
-unsigned char crocksdb_ingestexternalfileoptions_get_write_global_seqno(
-    const crocksdb_ingestexternalfileoptions_t* opt) {
-  return opt->rep.write_global_seqno;
-}
-
-void crocksdb_ingestexternalfileoptions_set_write_global_seqno(
-    crocksdb_ingestexternalfileoptions_t* opt,
-    unsigned char write_global_seqno) {
-  opt->rep.write_global_seqno = write_global_seqno;
-}
-
-void crocksdb_ingestexternalfileoptions_destroy(
-    crocksdb_ingestexternalfileoptions_t* opt) {
-  delete opt;
-}
-
-void crocksdb_ingest_external_file(
-    crocksdb_t* db, const char* const* file_list, const size_t list_len,
-    const crocksdb_ingestexternalfileoptions_t* opt, Status* s) {
+void crocksdb_ingest_external_file(crocksdb_t* db, const char* const* file_list,
+                                   const size_t list_len,
+                                   const IngestExternalFileOptions* opt,
+                                   Status* s) {
   std::vector<std::string> files(list_len);
   for (size_t i = 0; i < list_len; ++i) {
     files[i] = std::string(file_list[i]);
   }
-  *s = db->rep->IngestExternalFile(files, opt->rep);
+  *s = db->rep->IngestExternalFile(files, *opt);
 }
 
-void crocksdb_ingest_external_file_cf(
-    crocksdb_t* db, crocksdb_column_family_handle_t* handle,
-    const char* const* file_list, const size_t list_len,
-    const crocksdb_ingestexternalfileoptions_t* opt, Status* s) {
+void crocksdb_ingest_external_file_cf(crocksdb_t* db,
+                                      crocksdb_column_family_handle_t* handle,
+                                      const char* const* file_list,
+                                      const size_t list_len,
+                                      const IngestExternalFileOptions* opt,
+                                      Status* s) {
   std::vector<std::string> files(list_len);
   for (size_t i = 0; i < list_len; ++i) {
     files[i] = std::string(file_list[i]);
   }
-  *s = db->rep->IngestExternalFile(handle->rep, files, opt->rep);
+  *s = db->rep->IngestExternalFile(handle->rep, files, *opt);
 }
 
 unsigned char crocksdb_ingest_external_file_optimized(
     crocksdb_t* db, crocksdb_column_family_handle_t* handle,
     const char* const* file_list, const size_t list_len,
-    const crocksdb_ingestexternalfileoptions_t* opt, Status* s) {
+    const IngestExternalFileOptions* opt, Status* s) {
   std::vector<std::string> files(list_len);
   for (size_t i = 0; i < list_len; ++i) {
     files[i] = std::string(file_list[i]);
@@ -4457,7 +4219,7 @@ unsigned char crocksdb_ingest_external_file_optimized(
   // If the file being ingested is overlapped with the memtable, it
   // will block writes and wait for flushing, which can cause high
   // write latency. So we set `allow_blocking_flush = false`.
-  auto ingest_opts = opt->rep;
+  auto ingest_opts = *opt;
   ingest_opts.allow_blocking_flush = false;
   *s = db->rep->IngestExternalFile(handle->rep, files, ingest_opts);
   if (s->IsInvalidArgument() &&
@@ -4477,7 +4239,7 @@ unsigned char crocksdb_ingest_external_file_optimized(
     // We don't check the status of this flush because we will
     // fallback to a blocking ingestion anyway.
     db->rep->Flush(flush_opts, handle->rep);
-    *s = db->rep->IngestExternalFile(handle->rep, files, opt->rep);
+    *s = db->rep->IngestExternalFile(handle->rep, files, *opt);
   }
   return has_flush;
 }
@@ -4744,11 +4506,12 @@ crocksdb_logger_t* crocksdb_create_log_from_options(const char* path,
 
 void crocksdb_log_destroy(crocksdb_logger_t* logger) { delete logger; }
 
-crocksdb_pinnableslice_t* crocksdb_get_pinned(
-    crocksdb_t* db, const crocksdb_readoptions_t* options, const char* key,
-    size_t keylen, Status* s) {
+crocksdb_pinnableslice_t* crocksdb_get_pinned(crocksdb_t* db,
+                                              const ReadOptions* options,
+                                              const char* key, size_t keylen,
+                                              Status* s) {
   auto v = new crocksdb_pinnableslice_t;
-  *s = db->rep->Get(options->rep, db->rep->DefaultColumnFamily(),
+  *s = db->rep->Get(*options, db->rep->DefaultColumnFamily(),
                     Slice(key, keylen), &v->rep);
   if (s->ok()) {
     return v;
@@ -4759,12 +4522,11 @@ crocksdb_pinnableslice_t* crocksdb_get_pinned(
 }
 
 crocksdb_pinnableslice_t* crocksdb_get_pinned_cf(
-    crocksdb_t* db, const crocksdb_readoptions_t* options,
+    crocksdb_t* db, const ReadOptions* options,
     crocksdb_column_family_handle_t* column_family, const char* key,
     size_t keylen, Status* s) {
   auto v = new crocksdb_pinnableslice_t;
-  *s = db->rep->Get(options->rep, column_family->rep, Slice(key, keylen),
-                    &v->rep);
+  *s = db->rep->Get(*options, column_family->rep, Slice(key, keylen), &v->rep);
   if (s->ok()) {
     return v;
   } else {
@@ -5374,32 +5136,13 @@ const char* crocksdb_sst_file_meta_data_largestkey(
   return meta->rep.largestkey.data();
 }
 
-crocksdb_compaction_options_t* crocksdb_compaction_options_create() {
-  return new crocksdb_compaction_options_t();
-}
-
-void crocksdb_compaction_options_destroy(crocksdb_compaction_options_t* opts) {
-  delete opts;
-}
-
-void crocksdb_compaction_options_set_compression(
-    crocksdb_compaction_options_t* opts, CompressionType compression) {
-  opts->rep.compression = compression;
-}
-
-void crocksdb_compaction_options_set_output_file_size_limit(
-    crocksdb_compaction_options_t* opts, size_t size) {
-  opts->rep.output_file_size_limit = size;
-}
-
-void crocksdb_compaction_options_set_max_subcompactions(
-    crocksdb_compaction_options_t* opts, int v) {
-  opts->rep.max_subcompactions = v;
+void crocksdb_compaction_options_init(CompactionOptions* opt) {
+  *opt = CompactionOptions();
 }
 
 void crocksdb_compact_files_cf(crocksdb_t* db,
                                crocksdb_column_family_handle_t* cf,
-                               crocksdb_compaction_options_t* opts,
+                               const CompactionOptions* opts,
                                const char** input_file_names,
                                size_t input_file_count, int output_level,
                                Status* s) {
@@ -5407,7 +5150,7 @@ void crocksdb_compact_files_cf(crocksdb_t* db,
   for (size_t i = 0; i < input_file_count; i++) {
     input_files.push_back(input_file_names[i]);
   }
-  *s = db->rep->CompactFiles(opts->rep, cf->rep, input_files, output_level);
+  *s = db->rep->CompactFiles(*opts, cf->rep, input_files, output_level);
 }
 
 /* PerfContext */
@@ -6386,57 +6129,29 @@ void ctitandb_options_set_blob_run_mode(ctitandb_options_t* options,
 }
 
 /* TitanReadOptions */
-struct ctitandb_readoptions_t {
-  TitanReadOptions rep;
-};
 
-ctitandb_readoptions_t* ctitandb_readoptions_create() {
-  return new ctitandb_readoptions_t;
-}
-
-void ctitandb_readoptions_destroy(ctitandb_readoptions_t* opts) { delete opts; }
-
-unsigned char ctitandb_readoptions_key_only(ctitandb_readoptions_t* opts) {
-  return opts->rep.key_only;
-}
-
-void ctitandb_readoptions_set_key_only(ctitandb_readoptions_t* opts,
-                                       unsigned char v) {
-  opts->rep.key_only = v;
+void ctitandb_readoptions_init(TitanReadOptions* opt) {
+  *opt = TitanReadOptions();
 }
 
 crocksdb_iterator_t* ctitandb_create_iterator(
-    crocksdb_t* db, const crocksdb_readoptions_t* options,
-    const ctitandb_readoptions_t* titan_options) {
+    crocksdb_t* db, const TitanReadOptions* titan_options) {
   crocksdb_iterator_t* result = new crocksdb_iterator_t;
-  if (titan_options == nullptr) {
-    result->rep = db->rep->NewIterator(options->rep);
-  } else {
-    *(ReadOptions*)&titan_options->rep = options->rep;
-    result->rep =
-        static_cast<TitanDB*>(db->rep)->NewIterator(titan_options->rep);
-  }
+  result->rep = static_cast<TitanDB*>(db->rep)->NewIterator(*titan_options);
   return result;
 }
 
 crocksdb_iterator_t* ctitandb_create_iterator_cf(
-    crocksdb_t* db, const crocksdb_readoptions_t* options,
-    const ctitandb_readoptions_t* titan_options,
+    crocksdb_t* db, const TitanReadOptions* titan_options,
     crocksdb_column_family_handle_t* column_family) {
   crocksdb_iterator_t* result = new crocksdb_iterator_t;
-  if (titan_options == nullptr) {
-    result->rep = db->rep->NewIterator(options->rep, column_family->rep);
-  } else {
-    *(ReadOptions*)&titan_options->rep = options->rep;
-    result->rep = static_cast<TitanDB*>(db->rep)->NewIterator(
-        titan_options->rep, column_family->rep);
-  }
+  result->rep = static_cast<TitanDB*>(db->rep)->NewIterator(*titan_options,
+                                                            column_family->rep);
   return result;
 }
 
 void ctitandb_create_iterators(
-    crocksdb_t* db, crocksdb_readoptions_t* options,
-    ctitandb_readoptions_t* titan_options,
+    crocksdb_t* db, const TitanReadOptions* titan_options,
     crocksdb_column_family_handle_t** column_families,
     crocksdb_iterator_t** iterators, size_t size, Status* s) {
   std::vector<ColumnFamilyHandle*> column_families_vec(size);
@@ -6445,13 +6160,8 @@ void ctitandb_create_iterators(
   }
 
   std::vector<Iterator*> res;
-  if (titan_options == nullptr) {
-    *s = db->rep->NewIterators(options->rep, column_families_vec, &res);
-  } else {
-    *(ReadOptions*)&titan_options->rep = options->rep;
-    *s = static_cast<TitanDB*>(db->rep)->NewIterators(
-        titan_options->rep, column_families_vec, &res);
-  }
+  *s = static_cast<TitanDB*>(db->rep)->NewIterators(*titan_options,
+                                                    column_families_vec, &res);
   if (!s->ok()) {
     for (size_t i = 0; i < res.size(); i++) {
       delete res[i];

--- a/tirocks-sys/crocksdb/crocksdb/c.h
+++ b/tirocks-sys/crocksdb/crocksdb/c.h
@@ -68,6 +68,7 @@
 #include "titan/options.h"
 
 using namespace rocksdb;
+using namespace rocksdb::titandb;
 
 extern "C" {
 
@@ -95,7 +96,6 @@ typedef struct crocksdb_fifo_compaction_options_t
     crocksdb_fifo_compaction_options_t;
 typedef struct crocksdb_filelock_t crocksdb_filelock_t;
 typedef struct crocksdb_filterpolicy_t crocksdb_filterpolicy_t;
-typedef struct crocksdb_flushoptions_t crocksdb_flushoptions_t;
 typedef struct crocksdb_iterator_t crocksdb_iterator_t;
 typedef struct crocksdb_logger_t crocksdb_logger_t;
 typedef struct crocksdb_logger_impl_t crocksdb_logger_impl_t;
@@ -103,26 +103,21 @@ typedef struct crocksdb_mergeoperator_t crocksdb_mergeoperator_t;
 typedef struct crocksdb_options_t crocksdb_options_t;
 typedef struct crocksdb_column_family_descriptor
     crocksdb_column_family_descriptor;
-typedef struct crocksdb_compactoptions_t crocksdb_compactoptions_t;
 typedef struct crocksdb_block_based_table_options_t
     crocksdb_block_based_table_options_t;
 typedef struct crocksdb_cuckoo_table_options_t crocksdb_cuckoo_table_options_t;
 typedef struct crocksdb_randomfile_t crocksdb_randomfile_t;
-typedef struct crocksdb_readoptions_t crocksdb_readoptions_t;
 typedef struct crocksdb_seqfile_t crocksdb_seqfile_t;
 typedef struct crocksdb_slicetransform_t crocksdb_slicetransform_t;
 typedef struct crocksdb_snapshot_t crocksdb_snapshot_t;
 typedef struct crocksdb_writablefile_t crocksdb_writablefile_t;
 typedef struct crocksdb_writebatch_t crocksdb_writebatch_t;
-typedef struct crocksdb_writeoptions_t crocksdb_writeoptions_t;
 typedef struct crocksdb_universal_compaction_options_t
     crocksdb_universal_compaction_options_t;
 typedef struct crocksdb_livefiles_t crocksdb_livefiles_t;
 typedef struct crocksdb_column_family_handle_t crocksdb_column_family_handle_t;
 typedef struct crocksdb_envoptions_t crocksdb_envoptions_t;
 typedef struct crocksdb_sequential_file_t crocksdb_sequential_file_t;
-typedef struct crocksdb_ingestexternalfileoptions_t
-    crocksdb_ingestexternalfileoptions_t;
 typedef struct crocksdb_sstfilereader_t crocksdb_sstfilereader_t;
 typedef struct crocksdb_sstfilewriter_t crocksdb_sstfilewriter_t;
 typedef struct crocksdb_externalsstfileinfo_t crocksdb_externalsstfileinfo_t;
@@ -152,7 +147,6 @@ typedef struct crocksdb_column_family_meta_data_t
     crocksdb_column_family_meta_data_t;
 typedef struct crocksdb_level_meta_data_t crocksdb_level_meta_data_t;
 typedef struct crocksdb_sst_file_meta_data_t crocksdb_sst_file_meta_data_t;
-typedef struct crocksdb_compaction_options_t crocksdb_compaction_options_t;
 typedef struct crocksdb_perf_context_t crocksdb_perf_context_t;
 typedef struct crocksdb_iostats_context_t crocksdb_iostats_context_t;
 typedef struct crocksdb_writestallinfo_t crocksdb_writestallinfo_t;
@@ -356,63 +350,70 @@ extern C_ROCKSDB_LIBRARY_API void crocksdb_close(crocksdb_t* db);
 extern C_ROCKSDB_LIBRARY_API void crocksdb_pause_bg_work(crocksdb_t* db);
 extern C_ROCKSDB_LIBRARY_API void crocksdb_continue_bg_work(crocksdb_t* db);
 
-extern C_ROCKSDB_LIBRARY_API void crocksdb_put(
-    crocksdb_t* db, const crocksdb_writeoptions_t* options, const char* key,
-    size_t keylen, const char* val, size_t vallen, Status* s);
+extern C_ROCKSDB_LIBRARY_API void crocksdb_put(crocksdb_t* db,
+                                               const WriteOptions* options,
+                                               const char* key, size_t keylen,
+                                               const char* val, size_t vallen,
+                                               Status* s);
 
 extern C_ROCKSDB_LIBRARY_API void crocksdb_put_cf(
-    crocksdb_t* db, const crocksdb_writeoptions_t* options,
+    crocksdb_t* db, const WriteOptions* options,
     crocksdb_column_family_handle_t* column_family, const char* key,
     size_t keylen, const char* val, size_t vallen, Status* s);
 
-extern C_ROCKSDB_LIBRARY_API void crocksdb_delete(
-    crocksdb_t* db, const crocksdb_writeoptions_t* options, const char* key,
-    size_t keylen, Status* s);
+extern C_ROCKSDB_LIBRARY_API void crocksdb_delete(crocksdb_t* db,
+                                                  const WriteOptions* options,
+                                                  const char* key,
+                                                  size_t keylen, Status* s);
 
 extern C_ROCKSDB_LIBRARY_API void crocksdb_delete_cf(
-    crocksdb_t* db, const crocksdb_writeoptions_t* options,
+    crocksdb_t* db, const WriteOptions* options,
     crocksdb_column_family_handle_t* column_family, const char* key,
     size_t keylen, Status* s);
 
 extern C_ROCKSDB_LIBRARY_API void crocksdb_single_delete(
-    crocksdb_t* db, const crocksdb_writeoptions_t* options, const char* key,
-    size_t keylen, Status* s);
+    crocksdb_t* db, const WriteOptions* options, const char* key, size_t keylen,
+    Status* s);
 
 extern C_ROCKSDB_LIBRARY_API void crocksdb_single_delete_cf(
-    crocksdb_t* db, const crocksdb_writeoptions_t* options,
+    crocksdb_t* db, const WriteOptions* options,
     crocksdb_column_family_handle_t* column_family, const char* key,
     size_t keylen, Status* s);
 
 extern C_ROCKSDB_LIBRARY_API void crocksdb_delete_range_cf(
-    crocksdb_t* db, const crocksdb_writeoptions_t* options,
+    crocksdb_t* db, const WriteOptions* options,
     crocksdb_column_family_handle_t* column_family, const char* begin_key,
     size_t begin_keylen, const char* end_key, size_t end_keylen, Status* s);
 
-extern C_ROCKSDB_LIBRARY_API void crocksdb_merge(
-    crocksdb_t* db, const crocksdb_writeoptions_t* options, const char* key,
-    size_t keylen, const char* val, size_t vallen, Status* s);
+extern C_ROCKSDB_LIBRARY_API void crocksdb_merge(crocksdb_t* db,
+                                                 const WriteOptions* options,
+                                                 const char* key, size_t keylen,
+                                                 const char* val, size_t vallen,
+                                                 Status* s);
 
 extern C_ROCKSDB_LIBRARY_API void crocksdb_merge_cf(
-    crocksdb_t* db, const crocksdb_writeoptions_t* options,
+    crocksdb_t* db, const WriteOptions* options,
     crocksdb_column_family_handle_t* column_family, const char* key,
     size_t keylen, const char* val, size_t vallen, Status* s);
 
-extern C_ROCKSDB_LIBRARY_API void crocksdb_write(
-    crocksdb_t* db, const crocksdb_writeoptions_t* options,
-    crocksdb_writebatch_t* batch, Status* s);
+extern C_ROCKSDB_LIBRARY_API void crocksdb_write(crocksdb_t* db,
+                                                 const WriteOptions* options,
+                                                 crocksdb_writebatch_t* batch,
+                                                 Status* s);
 
 extern C_ROCKSDB_LIBRARY_API void crocksdb_write_multi_batch(
-    crocksdb_t* db, const crocksdb_writeoptions_t* options,
+    crocksdb_t* db, const WriteOptions* options,
     crocksdb_writebatch_t** batches, size_t batch_size, Status* s);
 
 /* Returns NULL if not found.  A malloc()ed array otherwise.
    Stores the length of the array in *vallen. */
-extern C_ROCKSDB_LIBRARY_API char* crocksdb_get(
-    crocksdb_t* db, const crocksdb_readoptions_t* options, const char* key,
-    size_t keylen, size_t* vallen, Status* s);
+extern C_ROCKSDB_LIBRARY_API char* crocksdb_get(crocksdb_t* db,
+                                                const ReadOptions* options,
+                                                const char* key, size_t keylen,
+                                                size_t* vallen, Status* s);
 
 extern C_ROCKSDB_LIBRARY_API char* crocksdb_get_cf(
-    crocksdb_t* db, const crocksdb_readoptions_t* options,
+    crocksdb_t* db, const ReadOptions* options,
     crocksdb_column_family_handle_t* column_family, const char* key,
     size_t keylen, size_t* vallen, Status* s);
 
@@ -428,26 +429,26 @@ extern C_ROCKSDB_LIBRARY_API char* crocksdb_get_cf(
 // each non-NULL values_list entry is a malloc()ed array, with
 // the length for each stored in values_list_sizes[i].
 extern C_ROCKSDB_LIBRARY_API void crocksdb_multi_get(
-    crocksdb_t* db, const crocksdb_readoptions_t* options, size_t num_keys,
+    crocksdb_t* db, const ReadOptions* options, size_t num_keys,
     const char* const* keys_list, const size_t* keys_list_sizes,
     char** values_list, size_t* values_list_sizes, Status* statuses);
 
 extern C_ROCKSDB_LIBRARY_API void crocksdb_multi_get_cf(
-    crocksdb_t* db, const crocksdb_readoptions_t* options,
+    crocksdb_t* db, const ReadOptions* options,
     const crocksdb_column_family_handle_t* const* column_families,
     size_t num_keys, const char* const* keys_list,
     const size_t* keys_list_sizes, char** values_list,
     size_t* values_list_sizes, Status* statuses);
 
 extern C_ROCKSDB_LIBRARY_API crocksdb_iterator_t* crocksdb_create_iterator(
-    crocksdb_t* db, const crocksdb_readoptions_t* options);
+    crocksdb_t* db, const ReadOptions* options);
 
 extern C_ROCKSDB_LIBRARY_API crocksdb_iterator_t* crocksdb_create_iterator_cf(
-    crocksdb_t* db, const crocksdb_readoptions_t* options,
+    crocksdb_t* db, const ReadOptions* options,
     crocksdb_column_family_handle_t* column_family);
 
 extern C_ROCKSDB_LIBRARY_API void crocksdb_create_iterators(
-    crocksdb_t* db, crocksdb_readoptions_t* opts,
+    crocksdb_t* db, const ReadOptions* opts,
     crocksdb_column_family_handle_t** column_families,
     crocksdb_iterator_t** iterators, size_t size, Status* s);
 
@@ -518,12 +519,12 @@ extern C_ROCKSDB_LIBRARY_API void crocksdb_compact_range_cf(
     size_t limit_key_len);
 
 extern C_ROCKSDB_LIBRARY_API void crocksdb_compact_range_opt(
-    crocksdb_t* db, crocksdb_compactoptions_t* opt, const char* start_key,
+    crocksdb_t* db, const CompactRangeOptions* opt, const char* start_key,
     size_t start_key_len, const char* limit_key, size_t limit_key_len);
 
 extern C_ROCKSDB_LIBRARY_API void crocksdb_compact_range_cf_opt(
     crocksdb_t* db, crocksdb_column_family_handle_t* column_family,
-    crocksdb_compactoptions_t* opt, const char* start_key, size_t start_key_len,
+    const CompactRangeOptions* opt, const char* start_key, size_t start_key_len,
     const char* limit_key, size_t limit_key_len);
 
 extern C_ROCKSDB_LIBRARY_API void crocksdb_delete_file(crocksdb_t* db,
@@ -533,16 +534,17 @@ extern C_ROCKSDB_LIBRARY_API void crocksdb_delete_file(crocksdb_t* db,
 extern C_ROCKSDB_LIBRARY_API const crocksdb_livefiles_t* crocksdb_livefiles(
     crocksdb_t* db);
 
-extern C_ROCKSDB_LIBRARY_API void crocksdb_flush(
-    crocksdb_t* db, const crocksdb_flushoptions_t* options, Status* s);
+extern C_ROCKSDB_LIBRARY_API void crocksdb_flush(crocksdb_t* db,
+                                                 const FlushOptions* options,
+                                                 Status* s);
 
 extern C_ROCKSDB_LIBRARY_API void crocksdb_flush_cf(
     crocksdb_t* db, crocksdb_column_family_handle_t* column_family,
-    const crocksdb_flushoptions_t* options, Status* s);
+    const FlushOptions* options, Status* s);
 
 extern C_ROCKSDB_LIBRARY_API void crocksdb_flush_cfs(
     crocksdb_t* db, const crocksdb_column_family_handle_t** column_familys,
-    int num_handles, const crocksdb_flushoptions_t* options, Status* s);
+    int num_handles, const FlushOptions* options, Status* s);
 
 extern C_ROCKSDB_LIBRARY_API void crocksdb_flush_wal(crocksdb_t* db,
                                                      unsigned char sync,
@@ -1447,98 +1449,23 @@ extern C_ROCKSDB_LIBRARY_API void crocksdb_mergeoperator_destroy(
     crocksdb_mergeoperator_t*);
 
 /* Read options */
-
-extern C_ROCKSDB_LIBRARY_API crocksdb_readoptions_t*
-crocksdb_readoptions_create();
-extern C_ROCKSDB_LIBRARY_API void crocksdb_readoptions_destroy(
-    crocksdb_readoptions_t*);
-extern C_ROCKSDB_LIBRARY_API void crocksdb_readoptions_set_verify_checksums(
-    crocksdb_readoptions_t*, unsigned char);
-extern C_ROCKSDB_LIBRARY_API void crocksdb_readoptions_set_fill_cache(
-    crocksdb_readoptions_t*, unsigned char);
-extern C_ROCKSDB_LIBRARY_API void crocksdb_readoptions_set_snapshot(
-    crocksdb_readoptions_t*, const crocksdb_snapshot_t*);
-extern C_ROCKSDB_LIBRARY_API void crocksdb_readoptions_set_iterate_lower_bound(
-    crocksdb_readoptions_t*, const char* key, size_t keylen);
-extern C_ROCKSDB_LIBRARY_API void crocksdb_readoptions_set_iterate_upper_bound(
-    crocksdb_readoptions_t*, const char* key, size_t keylen);
-extern C_ROCKSDB_LIBRARY_API void crocksdb_readoptions_set_read_tier(
-    crocksdb_readoptions_t*, ReadTier);
-extern C_ROCKSDB_LIBRARY_API void crocksdb_readoptions_set_tailing(
-    crocksdb_readoptions_t*, unsigned char);
-extern C_ROCKSDB_LIBRARY_API void crocksdb_readoptions_set_managed(
-    crocksdb_readoptions_t*, unsigned char);
-extern C_ROCKSDB_LIBRARY_API void crocksdb_readoptions_set_readahead_size(
-    crocksdb_readoptions_t*, size_t);
-extern C_ROCKSDB_LIBRARY_API void
-crocksdb_readoptions_set_max_skippable_internal_keys(crocksdb_readoptions_t*,
-                                                     uint64_t);
-extern C_ROCKSDB_LIBRARY_API void crocksdb_readoptions_set_total_order_seek(
-    crocksdb_readoptions_t*, unsigned char);
-extern C_ROCKSDB_LIBRARY_API void crocksdb_readoptions_set_prefix_same_as_start(
-    crocksdb_readoptions_t*, unsigned char);
-extern C_ROCKSDB_LIBRARY_API void crocksdb_readoptions_set_pin_data(
-    crocksdb_readoptions_t*, unsigned char);
-extern C_ROCKSDB_LIBRARY_API void
-crocksdb_readoptions_set_background_purge_on_iterator_cleanup(
-    crocksdb_readoptions_t*, unsigned char);
-extern C_ROCKSDB_LIBRARY_API void
-crocksdb_readoptions_set_ignore_range_deletions(crocksdb_readoptions_t*,
-                                                unsigned char);
 extern C_ROCKSDB_LIBRARY_API void crocksdb_readoptions_set_table_filter(
-    crocksdb_readoptions_t*, void*,
+    ReadOptions*, void*,
     unsigned char (*table_filter)(void*, const crocksdb_table_properties_t*),
     void (*destory)(void*));
 
 /* Write options */
 
-extern C_ROCKSDB_LIBRARY_API crocksdb_writeoptions_t*
-crocksdb_writeoptions_create();
-extern C_ROCKSDB_LIBRARY_API void crocksdb_writeoptions_destroy(
-    crocksdb_writeoptions_t*);
-extern C_ROCKSDB_LIBRARY_API void crocksdb_writeoptions_set_sync(
-    crocksdb_writeoptions_t*, unsigned char);
-extern C_ROCKSDB_LIBRARY_API void crocksdb_writeoptions_disable_wal(
-    crocksdb_writeoptions_t* opt, int disable);
-extern C_ROCKSDB_LIBRARY_API void
-crocksdb_writeoptions_set_ignore_missing_column_families(
-    crocksdb_writeoptions_t*, unsigned char);
-extern C_ROCKSDB_LIBRARY_API void crocksdb_writeoptions_set_no_slowdown(
-    crocksdb_writeoptions_t*, unsigned char);
-extern C_ROCKSDB_LIBRARY_API void crocksdb_writeoptions_set_low_pri(
-    crocksdb_writeoptions_t*, unsigned char);
+extern C_ROCKSDB_LIBRARY_API void crocksdb_writeoptions_init(WriteOptions*);
 
 /* Compact range options */
 
-extern C_ROCKSDB_LIBRARY_API crocksdb_compactoptions_t*
-crocksdb_compactoptions_create();
-extern C_ROCKSDB_LIBRARY_API void crocksdb_compactoptions_destroy(
-    crocksdb_compactoptions_t*);
-extern C_ROCKSDB_LIBRARY_API void
-crocksdb_compactoptions_set_exclusive_manual_compaction(
-    crocksdb_compactoptions_t*, unsigned char);
-extern C_ROCKSDB_LIBRARY_API void crocksdb_compactoptions_set_change_level(
-    crocksdb_compactoptions_t*, unsigned char);
-extern C_ROCKSDB_LIBRARY_API void crocksdb_compactoptions_set_target_level(
-    crocksdb_compactoptions_t*, int);
-extern C_ROCKSDB_LIBRARY_API void crocksdb_compactoptions_set_target_path_id(
-    crocksdb_compactoptions_t*, int);
-extern C_ROCKSDB_LIBRARY_API void
-crocksdb_compactoptions_set_max_subcompactions(crocksdb_compactoptions_t*, int);
-extern C_ROCKSDB_LIBRARY_API void
-crocksdb_compactoptions_set_bottommost_level_compaction(
-    crocksdb_compactoptions_t*, BottommostLevelCompaction);
+extern C_ROCKSDB_LIBRARY_API void crocksdb_compactrangeoptions_init(
+    CompactRangeOptions*);
 
 /* Flush options */
 
-extern C_ROCKSDB_LIBRARY_API crocksdb_flushoptions_t*
-crocksdb_flushoptions_create();
-extern C_ROCKSDB_LIBRARY_API void crocksdb_flushoptions_destroy(
-    crocksdb_flushoptions_t*);
-extern C_ROCKSDB_LIBRARY_API void crocksdb_flushoptions_set_wait(
-    crocksdb_flushoptions_t*, unsigned char);
-extern C_ROCKSDB_LIBRARY_API void crocksdb_flushoptions_set_allow_write_stall(
-    crocksdb_flushoptions_t*, unsigned char);
+extern C_ROCKSDB_LIBRARY_API void crocksdb_flushoptions_init(FlushOptions*);
 
 /* Memory allocator */
 
@@ -1694,7 +1621,7 @@ extern C_ROCKSDB_LIBRARY_API void crocksdb_sstfilereader_open(
 
 extern C_ROCKSDB_LIBRARY_API crocksdb_iterator_t*
 crocksdb_sstfilereader_new_iterator(crocksdb_sstfilereader_t* reader,
-                                    const crocksdb_readoptions_t* options);
+                                    const ReadOptions* options);
 
 extern C_ROCKSDB_LIBRARY_API void crocksdb_sstfilereader_read_table_properties(
     const crocksdb_sstfilereader_t* reader, void* ctx,
@@ -1756,44 +1683,22 @@ crocksdb_externalsstfileinfo_file_size(crocksdb_externalsstfileinfo_t*);
 extern C_ROCKSDB_LIBRARY_API uint64_t
 crocksdb_externalsstfileinfo_num_entries(crocksdb_externalsstfileinfo_t*);
 
-extern C_ROCKSDB_LIBRARY_API crocksdb_ingestexternalfileoptions_t*
-crocksdb_ingestexternalfileoptions_create();
-extern C_ROCKSDB_LIBRARY_API void
-crocksdb_ingestexternalfileoptions_set_move_files(
-    crocksdb_ingestexternalfileoptions_t* opt, unsigned char move_files);
-extern C_ROCKSDB_LIBRARY_API void
-crocksdb_ingestexternalfileoptions_set_snapshot_consistency(
-    crocksdb_ingestexternalfileoptions_t* opt,
-    unsigned char snapshot_consistency);
-extern C_ROCKSDB_LIBRARY_API void
-crocksdb_ingestexternalfileoptions_set_allow_global_seqno(
-    crocksdb_ingestexternalfileoptions_t* opt,
-    unsigned char allow_global_seqno);
-extern C_ROCKSDB_LIBRARY_API void
-crocksdb_ingestexternalfileoptions_set_allow_blocking_flush(
-    crocksdb_ingestexternalfileoptions_t* opt,
-    unsigned char allow_blocking_flush);
-extern C_ROCKSDB_LIBRARY_API unsigned char
-crocksdb_ingestexternalfileoptions_get_write_global_seqno(
-    const crocksdb_ingestexternalfileoptions_t* opt);
-extern C_ROCKSDB_LIBRARY_API void
-crocksdb_ingestexternalfileoptions_set_write_global_seqno(
-    crocksdb_ingestexternalfileoptions_t* opt,
-    unsigned char write_global_seqno);
-extern C_ROCKSDB_LIBRARY_API void crocksdb_ingestexternalfileoptions_destroy(
-    crocksdb_ingestexternalfileoptions_t* opt);
+extern C_ROCKSDB_LIBRARY_API void crocksdb_ingestexternalfileoptions_init(
+    IngestExternalFileOptions*);
 extern C_ROCKSDB_LIBRARY_API void crocksdb_ingest_external_file(
     crocksdb_t* db, const char* const* file_list, const size_t list_len,
-    const crocksdb_ingestexternalfileoptions_t* opt, Status* s);
+    const IngestExternalFileOptions* opt, Status* s);
 extern C_ROCKSDB_LIBRARY_API void crocksdb_ingest_external_file_cf(
     crocksdb_t* db, crocksdb_column_family_handle_t* handle,
     const char* const* file_list, const size_t list_len,
-    const crocksdb_ingestexternalfileoptions_t* opt, Status* s);
+    const IngestExternalFileOptions* opt, Status* s);
 extern C_ROCKSDB_LIBRARY_API unsigned char
-crocksdb_ingest_external_file_optimized(
-    crocksdb_t* db, crocksdb_column_family_handle_t* handle,
-    const char* const* file_list, const size_t list_len,
-    const crocksdb_ingestexternalfileoptions_t* opt, Status* s);
+crocksdb_ingest_external_file_optimized(crocksdb_t* db,
+                                        crocksdb_column_family_handle_t* handle,
+                                        const char* const* file_list,
+                                        const size_t list_len,
+                                        const IngestExternalFileOptions* opt,
+                                        Status* s);
 
 /* SliceTransform */
 
@@ -1898,10 +1803,10 @@ crocksdb_create_log_from_options(const char* path, crocksdb_options_t* opts,
 extern C_ROCKSDB_LIBRARY_API void crocksdb_log_destroy(crocksdb_logger_t*);
 
 extern C_ROCKSDB_LIBRARY_API crocksdb_pinnableslice_t* crocksdb_get_pinned(
-    crocksdb_t* db, const crocksdb_readoptions_t* options, const char* key,
-    size_t keylen, Status* s);
+    crocksdb_t* db, const ReadOptions* options, const char* key, size_t keylen,
+    Status* s);
 extern C_ROCKSDB_LIBRARY_API crocksdb_pinnableslice_t* crocksdb_get_pinned_cf(
-    crocksdb_t* db, const crocksdb_readoptions_t* options,
+    crocksdb_t* db, const ReadOptions* options,
     crocksdb_column_family_handle_t* column_family, const char* key,
     size_t keylen, Status* s);
 extern C_ROCKSDB_LIBRARY_API void crocksdb_pinnableslice_destroy(
@@ -2100,23 +2005,13 @@ extern C_ROCKSDB_LIBRARY_API const char* crocksdb_sst_file_meta_data_largestkey(
     const crocksdb_sst_file_meta_data_t*, size_t*);
 
 /* CompactFiles */
-extern C_ROCKSDB_LIBRARY_API crocksdb_compaction_options_t*
-crocksdb_compaction_options_create();
-extern C_ROCKSDB_LIBRARY_API void crocksdb_compaction_options_destroy(
-    crocksdb_compaction_options_t*);
-extern C_ROCKSDB_LIBRARY_API void crocksdb_compaction_options_set_compression(
-    crocksdb_compaction_options_t*, CompressionType);
-extern C_ROCKSDB_LIBRARY_API void
-crocksdb_compaction_options_set_output_file_size_limit(
-    crocksdb_compaction_options_t*, size_t);
-extern C_ROCKSDB_LIBRARY_API void
-crocksdb_compaction_options_set_max_subcompactions(
-    crocksdb_compaction_options_t*, int);
+extern C_ROCKSDB_LIBRARY_API void crocksdb_compaction_options_init(
+    CompactionOptions*);
 
 extern C_ROCKSDB_LIBRARY_API void crocksdb_compact_files_cf(
-    crocksdb_t*, crocksdb_column_family_handle_t*,
-    crocksdb_compaction_options_t*, const char** input_file_names,
-    size_t input_file_count, int output_level, Status* s);
+    crocksdb_t*, crocksdb_column_family_handle_t*, const CompactionOptions*,
+    const char** input_file_names, size_t input_file_count, int output_level,
+    Status* s);
 
 /* PerfContext */
 extern C_ROCKSDB_LIBRARY_API PerfLevel crocksdb_get_perf_level(void);
@@ -2433,7 +2328,6 @@ struct ctitandb_blob_index_t {
 };
 
 typedef struct ctitandb_options_t ctitandb_options_t;
-typedef struct ctitandb_readoptions_t ctitandb_readoptions_t;
 typedef struct ctitandb_blob_index_t ctitandb_blob_index_t;
 
 extern C_ROCKSDB_LIBRARY_API crocksdb_t* ctitandb_open_column_families(
@@ -2551,36 +2445,23 @@ extern void C_ROCKSDB_LIBRARY_API
 ctitandb_options_set_sample_ratio(ctitandb_options_t* options, double ratio);
 
 extern void C_ROCKSDB_LIBRARY_API ctitandb_options_set_blob_run_mode(
-    ctitandb_options_t* options, titandb::TitanBlobRunMode mode);
+    ctitandb_options_t* options, TitanBlobRunMode mode);
 
 /* TitanReadOptions */
 
-extern C_ROCKSDB_LIBRARY_API ctitandb_readoptions_t*
-ctitandb_readoptions_create();
-
-extern C_ROCKSDB_LIBRARY_API void ctitandb_readoptions_destroy(
-    ctitandb_readoptions_t* opts);
-
-extern C_ROCKSDB_LIBRARY_API unsigned char ctitandb_readoptions_key_only(
-    ctitandb_readoptions_t* opts);
-
-extern C_ROCKSDB_LIBRARY_API void ctitandb_readoptions_set_key_only(
-    ctitandb_readoptions_t* opts, unsigned char v);
+extern C_ROCKSDB_LIBRARY_API void ctitandb_readoptions_init(TitanReadOptions*);
 
 /* Titan Iterator */
 
 extern C_ROCKSDB_LIBRARY_API crocksdb_iterator_t* ctitandb_create_iterator(
-    crocksdb_t* db, const crocksdb_readoptions_t* options,
-    const ctitandb_readoptions_t* titan_options);
+    crocksdb_t* db, const TitanReadOptions* titan_options);
 
 extern C_ROCKSDB_LIBRARY_API crocksdb_iterator_t* ctitandb_create_iterator_cf(
-    crocksdb_t* db, const crocksdb_readoptions_t* options,
-    const ctitandb_readoptions_t* titan_options,
+    crocksdb_t* db, const TitanReadOptions* titan_options,
     crocksdb_column_family_handle_t* column_family);
 
 extern C_ROCKSDB_LIBRARY_API void ctitandb_create_iterators(
-    crocksdb_t* db, crocksdb_readoptions_t* options,
-    ctitandb_readoptions_t* titan_options,
+    crocksdb_t* db, const TitanReadOptions* titan_options,
     crocksdb_column_family_handle_t** column_families,
     crocksdb_iterator_t** iterators, size_t size, Status* s);
 

--- a/tirocks/src/lib.rs
+++ b/tirocks/src/lib.rs
@@ -4,6 +4,7 @@
 
 pub mod env;
 mod error;
+pub mod option;
 pub mod rate_limiter;
 
 pub use error::{Code, Result, Severity, Status, SubCode};

--- a/tirocks/src/option.rs
+++ b/tirocks/src/option.rs
@@ -19,23 +19,32 @@ pub use write::WriteOptions;
 ///
 /// The safety requires the slice is pinned. Not using pin here because
 /// we may use an array to manage multiple slices.
-struct OwnedSlie {
+struct OwnedSlice {
     data: Vec<u8>,
     slice: rocksdb_Slice,
 }
 
-impl OwnedSlie {
+impl OwnedSlice {
     #[inline]
-    fn set_data(&mut self, data: Vec<u8>) {
-        self.data = data;
-        self.slice = rocksdb_Slice {
-            data_: self.data.as_ptr() as _,
-            size_: self.data.len(),
+    fn set_data(&mut self, data: Option<Vec<u8>>) -> *mut rocksdb_Slice {
+        match data {
+            Some(data) => {
+                self.data = data;
+                self.slice = rocksdb_Slice {
+                    data_: self.data.as_ptr() as _,
+                    size_: self.data.len(),
+                };
+                &mut self.slice
+            }
+            None => {
+                *self = Default::default();
+                ptr::null_mut()
+            }
         }
     }
 }
 
-impl Default for OwnedSlie {
+impl Default for OwnedSlice {
     #[inline]
     fn default() -> Self {
         Self {

--- a/tirocks/src/option.rs
+++ b/tirocks/src/option.rs
@@ -1,0 +1,51 @@
+// Copyright 2022 TiKV Project Authors. Licensed under Apache-2.0.
+
+mod flush;
+mod read;
+mod write;
+
+use std::ptr;
+
+pub use flush::{
+    BottommostLevelCompaction, CompactRangeOptions, CompactionOptions, FlushOptions,
+    IngestExternalFileOptions,
+};
+pub use read::{ReadOptions, ReadTier};
+use tirocks_sys::{rocksdb_CompressionType, rocksdb_Slice};
+pub use write::WriteOptions;
+
+/// An owned slice that can be used with the weird rocksdb Options
+/// API, which requires a pointer to slice to outlive the options.
+///
+/// The safety requires the slice is pinned. Not using pin here because
+/// we may use an array to manage multiple slices.
+struct OwnedSlie {
+    data: Vec<u8>,
+    slice: rocksdb_Slice,
+}
+
+impl OwnedSlie {
+    #[inline]
+    fn set_data(&mut self, data: Vec<u8>) {
+        self.data = data;
+        self.slice = rocksdb_Slice {
+            data_: self.data.as_ptr() as _,
+            size_: self.data.len(),
+        }
+    }
+}
+
+impl Default for OwnedSlie {
+    #[inline]
+    fn default() -> Self {
+        Self {
+            data: Default::default(),
+            slice: rocksdb_Slice {
+                data_: ptr::null(),
+                size_: 0,
+            },
+        }
+    }
+}
+
+pub type CompressionType = rocksdb_CompressionType;

--- a/tirocks/src/option.rs
+++ b/tirocks/src/option.rs
@@ -14,6 +14,8 @@ pub use read::{ReadOptions, ReadTier};
 use tirocks_sys::{rocksdb_CompressionType, rocksdb_Slice};
 pub use write::WriteOptions;
 
+pub type CompressionType = rocksdb_CompressionType;
+
 /// An owned slice that can be used with the weird rocksdb Options
 /// API, which requires a pointer to slice to outlive the options.
 ///
@@ -56,5 +58,3 @@ impl Default for OwnedSlice {
         }
     }
 }
-
-pub type CompressionType = rocksdb_CompressionType;

--- a/tirocks/src/option/flush.rs
+++ b/tirocks/src/option/flush.rs
@@ -1,0 +1,277 @@
+// Copyright 2022 TiKV Project Authors. Licensed under Apache-2.0.
+
+use std::mem::MaybeUninit;
+
+use tirocks_sys::{
+    rocksdb_BottommostLevelCompaction, rocksdb_CompactRangeOptions, rocksdb_CompactionOptions,
+    rocksdb_FlushOptions, rocksdb_IngestExternalFileOptions,
+};
+
+use super::CompressionType;
+
+/// Options that control flush operations
+#[derive(Debug)]
+pub struct FlushOptions {
+    raw: rocksdb_FlushOptions,
+}
+
+impl Default for FlushOptions {
+    #[inline]
+    fn default() -> Self {
+        let mut opt = MaybeUninit::uninit();
+        unsafe {
+            tirocks_sys::crocksdb_flushoptions_init(opt.as_mut_ptr());
+            Self {
+                raw: opt.assume_init(),
+            }
+        }
+    }
+}
+
+impl FlushOptions {
+    /// If true, the flush will wait until the flush is done.
+    /// Default: true
+    #[inline]
+    pub fn set_wait(&mut self, wait: bool) -> &mut Self {
+        self.raw.wait = wait;
+        self
+    }
+
+    /// If true, the flush would proceed immediately even it means writes will
+    /// stall for the duration of the flush; if false the operation will wait
+    /// until it's possible to do flush w/o causing stall or until required flush
+    /// is performed by someone else (foreground call or background thread).
+    /// Default: false
+    #[inline]
+    pub fn set_allow_write_stall(&mut self, allow: bool) -> &mut Self {
+        self.raw.allow_write_stall = allow;
+        self
+    }
+}
+
+// CompactionOptions are used in CompactFiles() call.
+#[derive(Debug)]
+pub struct CompactionOptions {
+    raw: rocksdb_CompactionOptions,
+}
+
+impl Default for CompactionOptions {
+    #[inline]
+    fn default() -> Self {
+        let mut opt = MaybeUninit::uninit();
+        unsafe {
+            tirocks_sys::crocksdb_compaction_options_init(opt.as_mut_ptr());
+            Self {
+                raw: opt.assume_init(),
+            }
+        }
+    }
+}
+
+impl CompactionOptions {
+    /// Compaction output compression type
+    /// Default: snappy
+    /// If set to `kDisableCompressionOption`, RocksDB will choose compression type
+    /// according to the `ColumnFamilyOptions`, taking into account the output
+    /// level if `compression_per_level` is specified.
+    #[inline]
+    pub fn set_compression(&mut self, compression: CompressionType) -> &mut Self {
+        self.raw.compression = compression;
+        self
+    }
+
+    /// Compaction will create files of size `output_file_size_limit`.
+    /// Default: MAX, which means that compaction will create a single file
+    #[inline]
+    pub fn set_output_file_size_limit(&mut self, size_limit: u64) -> &mut Self {
+        self.raw.output_file_size_limit = size_limit;
+        self
+    }
+
+    /// If > 0, it will replace the option in the DBOptions for this compaction.
+    #[inline]
+    pub fn set_max_subcompactions(&mut self, subcompaction: u32) -> &mut Self {
+        self.raw.max_subcompactions = subcompaction;
+        self
+    }
+}
+
+pub type BottommostLevelCompaction = rocksdb_BottommostLevelCompaction;
+
+// CompactRangeOptions is used by CompactRange() call.
+#[derive(Debug)]
+pub struct CompactRangeOptions {
+    raw: rocksdb_CompactRangeOptions,
+}
+
+impl Default for CompactRangeOptions {
+    #[inline]
+    fn default() -> Self {
+        let mut opt = MaybeUninit::uninit();
+        unsafe {
+            tirocks_sys::crocksdb_compactrangeoptions_init(opt.as_mut_ptr());
+            Self {
+                raw: opt.assume_init(),
+            }
+        }
+    }
+}
+
+impl CompactRangeOptions {
+    /// If true, no other compaction will run at the same time as this
+    /// manual compaction
+    #[inline]
+    pub fn set_exclusive_manual_compaction(&mut self, exclusive: bool) -> &mut Self {
+        self.raw.exclusive_manual_compaction = exclusive;
+        self
+    }
+
+    /// If true, compacted files will be moved to the minimum level capable
+    /// of holding the data or given level (specified non-negative target_level).
+    #[inline]
+    pub fn set_change_level(&mut self, change_level: bool) -> &mut Self {
+        self.raw.change_level = change_level;
+        self
+    }
+
+    /// If change_level is true and target_level have non-negative value, compacted
+    /// files will be moved to target_level.
+    #[inline]
+    pub fn set_target_level(&mut self, target_level: i32) -> &mut Self {
+        self.raw.target_level = target_level;
+        self
+    }
+
+    /// Compaction outputs will be placed in options.db_paths[target_path_id].
+    /// Behavior is undefined if target_path_id is out of range.
+    #[inline]
+    pub fn set_target_path_id(&mut self, path_id: u32) -> &mut Self {
+        self.raw.target_path_id = path_id;
+        self
+    }
+
+    /// By default level based compaction will only compact the bottommost level
+    /// if there is a compaction filter
+    #[inline]
+    pub fn set_bottommost_level_compaction(
+        &mut self,
+        compaction: BottommostLevelCompaction,
+    ) -> &mut Self {
+        self.raw.bottommost_level_compaction = compaction;
+        self
+    }
+
+    /// If true, will execute immediately even if doing so would cause the DB to
+    /// enter write stall mode. Otherwise, it'll sleep until load is low enough.
+    #[inline]
+    pub fn set_allow_write_stall(&mut self, allow: bool) -> &mut Self {
+        self.raw.allow_write_stall = allow;
+        self
+    }
+
+    /// If > 0, it will replace the option in the DBOptions for this compaction.
+    #[inline]
+    pub fn set_max_subcompactions(&mut self, subcompaction: u32) -> &mut Self {
+        self.raw.max_subcompactions = subcompaction;
+        self
+    }
+}
+
+// IngestExternalFileOptions is used by IngestExternalFile()
+#[derive(Debug)]
+pub struct IngestExternalFileOptions {
+    raw: rocksdb_IngestExternalFileOptions,
+}
+
+impl Default for IngestExternalFileOptions {
+    #[inline]
+    fn default() -> Self {
+        let mut opt = MaybeUninit::uninit();
+        unsafe {
+            tirocks_sys::crocksdb_ingestexternalfileoptions_init(opt.as_mut_ptr());
+            Self {
+                raw: opt.assume_init(),
+            }
+        }
+    }
+}
+
+impl IngestExternalFileOptions {
+    /// Can be set to true to move the files instead of copying them.
+    #[inline]
+    pub fn set_move_files(&mut self, m: bool) -> &mut Self {
+        self.raw.move_files = m;
+        self
+    }
+
+    /// If set to true, ingestion falls back to copy when move fails.
+    #[inline]
+    pub fn set_failed_move_fall_back_to_copy(&mut self, fallback: bool) -> &mut Self {
+        self.raw.failed_move_fall_back_to_copy = fallback;
+        self
+    }
+
+    /// If set to false, an ingested file keys could appear in existing snapshots
+    /// that where created before the file was ingested.
+    #[inline]
+    pub fn set_snapshot_consistency(&mut self, consistency: bool) -> &mut Self {
+        self.raw.snapshot_consistency = consistency;
+        self
+    }
+
+    /// If set to false, IngestExternalFile() will fail if the file key range
+    /// overlaps with existing keys or tombstones in the DB.
+    #[inline]
+    pub fn set_allow_global_sequence_number(&mut self, allow: bool) -> &mut Self {
+        self.raw.allow_global_seqno = allow;
+        self
+    }
+
+    // If set to false and the file key range overlaps with the memtable key range
+    // (memtable flush required), IngestExternalFile will fail.
+    #[inline]
+    pub fn set_allow_blocking_flush(&mut self, allow: bool) -> &mut Self {
+        self.raw.allow_blocking_flush = allow;
+        self
+    }
+
+    /// Set to true if you would like duplicate keys in the file being ingested
+    /// to be skipped rather than overwriting existing data under that key.
+    /// Usecase: back-fill of some historical data in the database without
+    /// over-writing existing newer version of data.
+    /// This option could only be used if the DB has been running
+    /// with allow_ingest_behind=true since the dawn of time.
+    /// All files will be ingested at the bottommost level with seqno=0.
+    #[inline]
+    pub fn set_ingest_behind(&mut self, behind: bool) -> &mut Self {
+        self.raw.ingest_behind = behind;
+        self
+    }
+
+    /// Set to true if you would like to write global_seqno to a given offset in
+    /// the external SST file for backward compatibility. Older versions of
+    /// RocksDB writes a global_seqno to a given offset within ingested SST files,
+    /// and new versions of RocksDB do not. If you ingest an external SST using
+    /// new version of RocksDB and would like to be able to downgrade to an
+    /// older version of RocksDB, you should set 'write_global_seqno' to true. If
+    /// your service is just starting to use the new RocksDB, we recommend that
+    /// you set this option to false, which brings two benefits:
+    /// 1. No extra random write for global_seqno during ingestion.
+    /// 2. Without writing external SST file, it's possible to do checksum.
+    /// We have a plan to set this option to false by default in the future.
+    #[inline]
+    pub fn set_write_global_sequence_number(&mut self, write: bool) -> &mut Self {
+        self.raw.write_global_seqno = write;
+        self
+    }
+
+    /// Set to true if you would like to verify the checksums of each block of the
+    /// external SST file before ingestion.
+    /// Warning: setting this to true causes slowdown in file ingestion because
+    /// the external SST file has to be read.
+    #[inline]
+    pub fn set_verify_checksums_before_ingest(&mut self, verify: bool) -> &mut Self {
+        self.raw.verify_checksums_before_ingest = verify;
+        self
+    }
+}

--- a/tirocks/src/option/read.rs
+++ b/tirocks/src/option/read.rs
@@ -1,0 +1,247 @@
+// Copyright 2022 TiKV Project Authors. Licensed under Apache-2.0.
+
+use std::{
+    fmt::{self, Debug, Formatter},
+    mem::MaybeUninit,
+};
+
+use tirocks_sys::rocksdb_titandb_TitanReadOptions;
+
+use super::OwnedSlie;
+
+pub type ReadTier = tirocks_sys::rocksdb_ReadTier;
+pub type SequenceNumber = tirocks_sys::rocksdb_SequenceNumber;
+
+/// Options that control read operations
+pub struct ReadOptions {
+    raw: rocksdb_titandb_TitanReadOptions,
+    // Storage for iterate_lower_bound, iterate_upper_bound and timestamp.
+    slice_store: Option<Box<[OwnedSlie; 3]>>,
+}
+
+impl Default for ReadOptions {
+    #[inline]
+    fn default() -> ReadOptions {
+        let mut opt = MaybeUninit::uninit();
+        unsafe {
+            tirocks_sys::ctitandb_readoptions_init(opt.as_mut_ptr());
+            ReadOptions {
+                raw: opt.assume_init(),
+                slice_store: None,
+            }
+        }
+    }
+}
+
+impl Debug for ReadOptions {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        write!(f, "{:?}", self.raw)
+    }
+}
+
+impl ReadOptions {
+    #[inline]
+    fn init_slice_store(&mut self) {
+        if self.slice_store.is_none() {
+            self.slice_store = Some(Box::new(Default::default()));
+        }
+    }
+
+    /// Sets the smallest key at which the backward iterator can return an
+    /// entry. Once the bound is passed, Valid() will be false. It is inclusive
+    /// ie the bound value is a valid entry.
+    ///
+    /// If prefix_extractor is set, the Seek target and `iterate_lower_bound`
+    /// need to have the same prefix. This is because ordering is not guaranteed
+    /// outside of prefix domain.
+    #[inline]
+    pub fn set_iterate_lower_bound(&mut self, lower_bound: Vec<u8>) -> &mut Self {
+        self.init_slice_store();
+        let arr = self.slice_store.as_mut().unwrap();
+        arr[0].set_data(lower_bound);
+        self.raw._base.iterate_lower_bound = &mut arr[0].slice;
+        self
+    }
+
+    /// Sets the extent upto which the forward iterator can returns entries.
+    /// Once the bound is reached, Valid() will be false. It is exclusive ie
+    /// the bound value is not a valid entry.
+    ///
+    /// If iterator_extractor is not null, the Seek target and
+    /// iterate_upper_bound need to have the same prefix. This is because
+    /// ordering is not guaranteed outside of prefix domain.
+    #[inline]
+    pub fn set_iterate_upper_bound(&mut self, upper_bound: Vec<u8>) -> &mut Self {
+        self.init_slice_store();
+        let arr = self.slice_store.as_mut().unwrap();
+        arr[1].set_data(upper_bound);
+        self.raw._base.iterate_lower_bound = &mut arr[1].slice;
+        self
+    }
+
+    /// RocksDB does auto-readahead for iterators on noticing more than two reads
+    /// for a table file. The readahead starts at 8KB and doubles on every
+    /// additional read upto 256KB.
+    /// This option can help if most of the range scans are large, and if it is
+    /// determined that a larger readahead than that enabled by auto-readahead is
+    /// needed.
+    /// Using a large readahead size (> 2MB) can typically improve the performance
+    /// of forward iteration on spinning disks.
+    /// Default is 0.
+    #[inline]
+    pub fn set_readahead_size(&mut self, size: usize) -> &mut Self {
+        self.raw._base.readahead_size = size;
+        self
+    }
+
+    /// A threshold for the number of keys that can be skipped before failing an
+    /// iterator seek as incomplete. The default value of 0 should be used to
+    /// never fail a request as incomplete, even on skipping too many keys.
+    /// Default: 0
+    #[inline]
+    pub fn set_max_skippable_internal_keys(&mut self, keys: u64) -> &mut Self {
+        self.raw._base.max_skippable_internal_keys = keys;
+        self
+    }
+
+    /// Specify if this read request should process data that ALREADY
+    /// resides on a particular cache. If the required data is not
+    /// found at the specified cache, then Status::Incomplete is returned.
+    /// Default: kReadAllTier
+    #[inline]
+    pub fn set_read_tier(&mut self, read_tier: ReadTier) -> &mut Self {
+        self.raw._base.read_tier = read_tier;
+        self
+    }
+
+    /// If true, all data read from underlying storage will be
+    /// verified against corresponding checksums.
+    /// Default: true
+    #[inline]
+    pub fn set_verify_checksums(&mut self, check: bool) -> &mut Self {
+        self.raw._base.verify_checksums = check;
+        self
+    }
+
+    /// Set whether the "data block"/"index block"" read for this iteration be
+    /// placed in block cache.
+    ///
+    /// Callers may wish to set this field to false for bulk scans. This would
+    /// help not to the change eviction order of existing items in the block
+    /// cache.
+    /// Default: true
+    #[inline]
+    pub fn set_fill_cache(&mut self, fill: bool) -> &mut Self {
+        self.raw._base.fill_cache = fill;
+        self
+    }
+
+    /// Specify to create a tailing iterator -- a special iterator that has a
+    /// view of the complete database (i.e. it can also be used to read newly
+    /// added data) and is optimized for sequential reads. It will return records
+    /// that were inserted into the database after the creation of the iterator.
+    /// Default: false
+    #[inline]
+    pub fn set_tailing(&mut self, tailing: bool) -> &mut Self {
+        self.raw._base.tailing = tailing;
+        self
+    }
+
+    /// Enable a total order seek regardless of index format (e.g. hash index)
+    /// used in the table. Some table format (e.g. plain table) may not support
+    /// this option.
+    /// If true when calling Get(), we also skip prefix bloom when reading from
+    /// block based table. It provides a way to read existing data after
+    /// changing implementation of prefix extractor.
+    #[inline]
+    pub fn set_total_order_seek(&mut self, total_order_seek: bool) -> &mut Self {
+        self.raw._base.total_order_seek = total_order_seek;
+        self
+    }
+
+    /// Enforce that the iterator only iterates over the same prefix as the seek.
+    /// This option is effective only for prefix seeks, i.e. prefix_extractor is
+    /// non-null for the column family and total_order_seek is false.  Unlike
+    /// iterate_upper_bound, prefix_same_as_start only works within a prefix
+    /// but in both directions.
+    /// Default: false
+    #[inline]
+    pub fn set_prefix_same_as_start(&mut self, same_as_start: bool) -> &mut Self {
+        self.raw._base.prefix_same_as_start = same_as_start;
+        self
+    }
+
+    /// Keep the blocks loaded by the iterator pinned in memory as long as the
+    /// iterator is not deleted, If used when reading from tables created with
+    /// BlockBasedTableOptions::use_delta_encoding = false,
+    /// Iterator's property "rocksdb.iterator.is-key-pinned" is guaranteed to
+    /// return 1.
+    /// Default: false
+    #[inline]
+    pub fn set_pin_data(&mut self, pin_data: bool) -> &mut Self {
+        self.raw._base.pin_data = pin_data;
+        self
+    }
+
+    /// If true, when PurgeObsoleteFile is called in CleanupIteratorState, we
+    /// schedule a background job in the flush job queue and delete obsolete files
+    /// in background.
+    /// Default: false
+    #[inline]
+    pub fn set_background_purge_on_iterator_cleanup(
+        &mut self,
+        background_purge: bool,
+    ) -> &mut Self {
+        self.raw._base.background_purge_on_iterator_cleanup = background_purge;
+        self
+    }
+
+    /// If true, keys deleted using the DeleteRange() API will be visible to
+    /// readers until they are naturally deleted during compaction. This improves
+    /// read performance in DBs with many range deletions.
+    /// Default: false
+    #[inline]
+    pub fn set_ignore_range_deletions(&mut self, ignore: bool) -> &mut Self {
+        self.raw._base.ignore_range_deletions = ignore;
+        self
+    }
+
+    /// Needed to support differential snapshots. Has 2 effects:
+    /// 1) Iterator will skip all internal keys with seq < iter_start_seqnum
+    /// 2) if this param > 0 iterator will return INTERNAL keys instead of
+    ///    user keys; e.g. return tombstones as well.
+    /// Default: 0 (don't filter by seq, return user keys)
+    #[inline]
+    pub fn set_iter_start_sequence_number(&mut self, seq: SequenceNumber) -> &mut Self {
+        self.raw._base.iter_start_seqnum = seq;
+        self
+    }
+
+    /// Timestamp of operation. Read should return the latest data visible to the
+    /// specified timestamp. All timestamps of the same database must be of the
+    /// same length and format. The user is responsible for providing a customized
+    /// compare function via Comparator to order <key, timestamp> tuples.
+    /// The user-specified timestamp feature is still under active development,
+    /// and the API is subject to change.
+    #[inline]
+    pub fn set_timestamp(&mut self, timestamp: Vec<u8>) -> &mut Self {
+        self.init_slice_store();
+        let arr = self.slice_store.as_mut().unwrap();
+        arr[2].set_data(timestamp);
+        self.raw._base.timestamp = &mut arr[2].slice;
+        self
+    }
+
+    /// If true, it will just return keys without indexing value from blob files.
+    /// It is mainly used for the scan-delete operation after DeleteFilesInRange.
+    /// Cause DeleteFilesInRange may expose old blob index keys, returning key only
+    /// avoids referring to missing blob files. Only used for titan engine.
+    ///
+    /// Default: false
+    #[inline]
+    pub fn set_key_only(&mut self, key_only: bool) -> &mut Self {
+        self.raw.key_only = key_only;
+        self
+    }
+    // TODO: support table filter.
+}

--- a/tirocks/src/option/write.rs
+++ b/tirocks/src/option/write.rs
@@ -1,0 +1,122 @@
+// Copyright 2022 TiKV Project Authors. Licensed under Apache-2.0.
+
+use std::fmt::{self, Debug, Formatter};
+use std::mem::MaybeUninit;
+
+use tirocks_sys::rocksdb_WriteOptions;
+
+use super::OwnedSlie;
+
+/// Options that control write operations
+pub struct WriteOptions {
+    raw: rocksdb_WriteOptions,
+    // Storage for iterate_lower_bound, iterate_upper_bound and timestamp.
+    slice_store: Option<Box<OwnedSlie>>,
+}
+
+impl Default for WriteOptions {
+    #[inline]
+    fn default() -> Self {
+        let mut opt = MaybeUninit::uninit();
+        unsafe {
+            tirocks_sys::crocksdb_writeoptions_init(opt.as_mut_ptr());
+            Self {
+                raw: opt.assume_init(),
+                slice_store: None,
+            }
+        }
+    }
+}
+
+impl Debug for WriteOptions {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        write!(f, "{:?}", self.raw)
+    }
+}
+
+impl WriteOptions {
+    /// If true, the write will be flushed from the operating system
+    /// buffer cache (by calling WritableFile::Sync()) before the write
+    /// is considered complete.  If this flag is true, writes will be
+    /// slower.
+    ///
+    /// If this flag is false, and the machine crashes, some recent
+    /// writes may be lost.  Note that if it is just the process that
+    /// crashes (i.e., the machine does not reboot), no writes will be
+    /// lost even if sync==false.
+    ///
+    /// In other words, a DB write with sync==false has similar
+    /// crash semantics as the "write()" system call.  A DB write
+    /// with sync==true has similar crash semantics to a "write()"
+    /// system call followed by "fdatasync()".
+    ///
+    /// Default: false
+    #[inline]
+    pub fn set_sync(&mut self, sync: bool) -> &mut Self {
+        self.raw.sync = sync;
+        self
+    }
+
+    /// If true, writes will not first go to the write ahead log,
+    /// and the write may get lost after a crash. The backup engine
+    /// relies on write-ahead logs to back up the memtable, so if
+    /// you disable write-ahead logs, you must create backups with
+    /// flush_before_backup=true to avoid losing unflushed memtable data.
+    /// Default: false
+    #[inline]
+    pub fn set_disable_wal(&mut self, disable_wal: bool) -> &mut Self {
+        self.raw.disableWAL = disable_wal;
+        self
+    }
+
+    /// If true and if user is trying to write to column families that don't exist
+    /// (they were dropped),  ignore the write (don't return an error). If there
+    /// are multiple writes in a WriteBatch, other writes will succeed.
+    /// Default: false
+    #[inline]
+    pub fn set_ignore_missing_column_families(&mut self, ignore: bool) -> &mut Self {
+        self.raw.ignore_missing_column_families = ignore;
+        self
+    }
+
+    /// If true and we need to wait or sleep for the write request, fails
+    /// immediately with Status::Incomplete().
+    /// Default: false
+    #[inline]
+    pub fn set_no_slowdown(&mut self, no_slowdown: bool) -> &mut Self {
+        self.raw.no_slowdown = no_slowdown;
+        self
+    }
+
+    /// If true, this write request is of lower priority if compaction is
+    /// behind. In this case, no_slowdown = true, the request will be cancelled
+    /// immediately with Status::Incomplete() returned. Otherwise, it will be
+    /// slowed down. The slowdown value is determined by RocksDB to guarantee
+    /// it introduces minimum impacts to high priority writes.
+    ///
+    /// Default: false
+    #[inline]
+    pub fn set_low_priority(&mut self, low: bool) -> &mut Self {
+        self.raw.low_pri = low;
+        self
+    }
+
+    /// Timestamp of write operation, e.g. Put. All timestamps of the same
+    /// database must share the same length and format. The user is also
+    /// responsible for providing a customized compare function via Comparator to
+    /// order <key, timestamp> tuples. If the user wants to enable timestamp, then
+    /// all write operations must be associated with timestamp because RocksDB, as
+    /// a single-node storage engine currently has no knowledge of global time,
+    /// thus has to rely on the application.
+    /// The user-specified timestamp feature is still under active development,
+    /// and the API is subject to change.
+    #[inline]
+    pub fn set_timestamp(&mut self, timestamp: Vec<u8>) -> &mut Self {
+        let ts = self
+            .slice_store
+            .get_or_insert_with(|| Box::new(Default::default()));
+        ts.set_data(timestamp);
+        self.raw.timestamp = &mut ts.slice;
+        self
+    }
+}

--- a/tirocks/src/option/write.rs
+++ b/tirocks/src/option/write.rs
@@ -5,13 +5,13 @@ use std::mem::MaybeUninit;
 
 use tirocks_sys::rocksdb_WriteOptions;
 
-use super::OwnedSlie;
+use super::OwnedSlice;
 
 /// Options that control write operations
 pub struct WriteOptions {
     raw: rocksdb_WriteOptions,
     // Storage for iterate_lower_bound, iterate_upper_bound and timestamp.
-    slice_store: Option<Box<OwnedSlie>>,
+    slice_store: Option<Box<OwnedSlice>>,
 }
 
 impl Default for WriteOptions {
@@ -111,12 +111,11 @@ impl WriteOptions {
     /// The user-specified timestamp feature is still under active development,
     /// and the API is subject to change.
     #[inline]
-    pub fn set_timestamp(&mut self, timestamp: Vec<u8>) -> &mut Self {
+    pub fn set_timestamp(&mut self, timestamp: impl Into<Option<Vec<u8>>>) -> &mut Self {
         let ts = self
             .slice_store
             .get_or_insert_with(|| Box::new(Default::default()));
-        ts.set_data(timestamp);
-        self.raw.timestamp = &mut ts.slice;
+        self.raw.timestamp = ts.set_data(timestamp.into());
         self
     }
 }


### PR DESCRIPTION
DBOptions and ColumnFamilyOptions require a lot of changes, will leave to next PR.

Most changes are just wrapping struct in rocksdb/option.h. Compared to rust-rocksdb, the main differences are:
- No C struct indirect access
- No allocations until byte slices involved