### PR TITLE
*: support properties

### DIFF
--- a/tirocks-sys/bindings/bindings.rs
+++ b/tirocks-sys/bindings/bindings.rs
@@ -130,15 +130,6 @@ pub enum rocksdb_EntryType {
     kEntryBlobIndex = 5,
     kEntryOther = 6,
 }
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct rocksdb_TablePropertiesCollectorFactory_Context {
-    pub column_family_id: u32,
-}
-extern "C" {
-    #[link_name = "\u{1}__ZN7rocksdb31TablePropertiesCollectorFactory7Context20kUnknownColumnFamilyE"]
-    pub static rocksdb_TablePropertiesCollectorFactory_Context_kUnknownColumnFamily: u32;
-}
 #[repr(i32)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub enum rocksdb_BackgroundErrorReason {
@@ -4608,7 +4599,7 @@ extern "C" {
         create_table_properties_collector: ::std::option::Option<
             unsafe extern "C" fn(
                 arg1: *mut libc::c_void,
-                context: rocksdb_TablePropertiesCollectorFactory_Context,
+                column_family_id: u32,
             ) -> *mut crocksdb_table_properties_collector_t,
         >,
     ) -> *mut crocksdb_table_properties_collector_factory_t;

--- a/tirocks-sys/build.rs
+++ b/tirocks-sys/build.rs
@@ -43,12 +43,12 @@ fn bindgen_rocksdb(file_path: &Path) {
         .allowlist_type(r"\brocksdb::titandb::HistogramType")
         .opaque_type(r"\brocksdb::Env")
         // Just blocking the type will still include its dependencies.
-        .opaque_type(r"\brocksdb::TableProperties")
+        .opaque_type(r"\brocksdb::(TableProperties|titandb::TitanDBOptions|FlushJobInfo|UserCollectedProperties)")
         // Block all system headers
         .blocklist_file(r"^/.*")
         .blocklist_type(r"\brocksdb::Env_FileAttributes")
         // `TableProperties` has different size on different platform.
-        .blocklist_type(r"\brocksdb::TableProperties")
+        .blocklist_type(r"\brocksdb::(TableProperties|titandb::TitanDBOptions|FlushJobInfo|UserCollectedProperties|TablePropertiesCollection|CompactionJobInfo|CompactionJobStats|SubcompactionJobInfo|ExternalFileIngestionInfo|WriteStallInfo)")
         .with_codegen_config(
             bindgen::CodegenConfig::FUNCTIONS
                 | bindgen::CodegenConfig::VARS

--- a/tirocks-sys/build.rs
+++ b/tirocks-sys/build.rs
@@ -43,7 +43,7 @@ fn bindgen_rocksdb(file_path: &Path) {
         .allowlist_type(r"\brocksdb::titandb::HistogramType")
         .opaque_type(r"\brocksdb::Env")
         // Just blocking the type will still include its dependencies.
-        .opaque_type(r"\brocksdb::(TableProperties|titandb::TitanDBOptions|FlushJobInfo|UserCollectedProperties)")
+        .opaque_type(r"\brocksdb::(TableProperties|titandb::TitanDBOptions|FlushJobInfo|UserCollectedProperties|TablePropertiesCollection|CompactionJobInfo|CompactionJobStats|SubcompactionJobInfo|ExternalFileIngestionInfo|WriteStallInfo)")
         // Block all system headers
         .blocklist_file(r"^/.*")
         .blocklist_type(r"\brocksdb::Env_FileAttributes")

--- a/tirocks-sys/crocksdb/c.cc
+++ b/tirocks-sys/crocksdb/c.cc
@@ -4823,7 +4823,7 @@ struct crocksdb_table_properties_collector_factory_t
   const char* (*name_)(void*);
   void (*destruct_)(void*);
   crocksdb_table_properties_collector_t* (*create_table_properties_collector_)(
-      void*, TablePropertiesCollectorFactory::Context context);
+      void*, uint32_t column_family_id);
 
   virtual ~crocksdb_table_properties_collector_factory_t() {
     destruct_(state_);
@@ -4831,7 +4831,7 @@ struct crocksdb_table_properties_collector_factory_t
 
   virtual TablePropertiesCollector* CreateTablePropertiesCollector(
       TablePropertiesCollectorFactory::Context ctx) override {
-    return create_table_properties_collector_(state_, ctx);
+    return create_table_properties_collector_(state_, ctx.column_family_id);
   }
 
   const char* Name() const override { return name_(state_); }
@@ -4841,7 +4841,7 @@ crocksdb_table_properties_collector_factory_t*
 crocksdb_table_properties_collector_factory_create(
     void* state, const char* (*name)(void*), void (*destruct)(void*),
     crocksdb_table_properties_collector_t* (*create_table_properties_collector)(
-        void*, TablePropertiesCollectorFactory::Context context)) {
+        void*, uint32_t column_family_id)) {
   auto f = new crocksdb_table_properties_collector_factory_t;
   f->state_ = state;
   f->name_ = name;

--- a/tirocks-sys/crocksdb/c.cc
+++ b/tirocks-sys/crocksdb/c.cc
@@ -2097,10 +2097,9 @@ const char* crocksdb_flushjobinfo_file_path(const crocksdb_flushjobinfo_t* info,
   return info->rep.file_path.data();
 }
 
-const crocksdb_table_properties_t* crocksdb_flushjobinfo_table_properties(
+const TableProperties* crocksdb_flushjobinfo_table_properties(
     const crocksdb_flushjobinfo_t* info) {
-  return reinterpret_cast<const crocksdb_table_properties_t*>(
-      &info->rep.table_properties);
+  return &info->rep.table_properties;
 }
 
 unsigned char crocksdb_flushjobinfo_triggered_writes_slowdown(
@@ -2150,11 +2149,9 @@ const char* crocksdb_compactionjobinfo_output_file_at(
   return path.data();
 }
 
-const crocksdb_table_properties_collection_t*
-crocksdb_compactionjobinfo_table_properties(
+const TablePropertiesCollection* crocksdb_compactionjobinfo_table_properties(
     const crocksdb_compactionjobinfo_t* info) {
-  return reinterpret_cast<const crocksdb_table_properties_collection_t*>(
-      &info->rep.table_properties);
+  return &info->rep.table_properties;
 }
 
 uint64_t crocksdb_compactionjobinfo_elapsed_micros(
@@ -2254,11 +2251,9 @@ const char* crocksdb_externalfileingestioninfo_internal_file_path(
   return info->rep.internal_file_path.data();
 }
 
-const crocksdb_table_properties_t*
-crocksdb_externalfileingestioninfo_table_properties(
+const TableProperties* crocksdb_externalfileingestioninfo_table_properties(
     const crocksdb_externalfileingestioninfo_t* info) {
-  return reinterpret_cast<const crocksdb_table_properties_t*>(
-      &info->rep.table_properties);
+  return &info->rep.table_properties;
 }
 
 const int crocksdb_externalfileingestioninfo_picked_level(
@@ -3445,10 +3440,9 @@ void crocksdb_compactionfiltercontext_file_numbers(
   *len = context->rep.file_numbers.size();
 }
 
-crocksdb_table_properties_t* crocksdb_compactionfiltercontext_table_properties(
+const TableProperties* crocksdb_compactionfiltercontext_table_properties(
     crocksdb_compactionfiltercontext_t* context, size_t offset) {
-  return (crocksdb_table_properties_t*)context->rep.table_properties[offset]
-      .get();
+  return context->rep.table_properties[offset].get();
 }
 
 const char* crocksdb_compactionfiltercontext_start_key(
@@ -3610,8 +3604,7 @@ struct TableFilter {
   // several times, so we need use shared_ptr to control the ctx_ resource
   // destroy ctx_ only when the last ReadOptions out of its life time.
   TableFilter(void* ctx,
-              unsigned char (*table_filter)(void*,
-                                            const crocksdb_table_properties_t*),
+              unsigned char (*table_filter)(void*, const TableProperties*),
               void (*destroy)(void*))
       : ctx_(std::make_shared<TableFilterCtx>(ctx, destroy)),
         table_filter_(table_filter) {}
@@ -3620,13 +3613,11 @@ struct TableFilter {
       : ctx_(f.ctx_), table_filter_(f.table_filter_) {}
 
   bool operator()(const TableProperties& prop) {
-    return table_filter_(
-        ctx_->ctx_,
-        reinterpret_cast<const crocksdb_table_properties_t*>(&prop));
+    return table_filter_(ctx_->ctx_, &prop);
   }
 
   shared_ptr<TableFilterCtx> ctx_;
-  unsigned char (*table_filter_)(void*, const crocksdb_table_properties_t*);
+  unsigned char (*table_filter_)(void*, const TableProperties*);
 
  private:
   TableFilter() {}
@@ -3634,7 +3625,7 @@ struct TableFilter {
 
 void crocksdb_readoptions_set_table_filter(
     ReadOptions* opt, void* ctx,
-    unsigned char (*table_filter)(void*, const crocksdb_table_properties_t*),
+    unsigned char (*table_filter)(void*, const TableProperties*),
     void (*destroy)(void*)) {
   opt->table_filter = TableFilter(ctx, table_filter, destroy);
 }
@@ -4043,11 +4034,9 @@ crocksdb_iterator_t* crocksdb_sstfilereader_new_iterator(
   return it;
 }
 
-void crocksdb_sstfilereader_read_table_properties(
-    const crocksdb_sstfilereader_t* reader, void* ctx,
-    void (*cb)(void*, const crocksdb_table_properties_t*)) {
-  auto props = reader->rep->GetTableProperties();
-  cb(ctx, reinterpret_cast<const crocksdb_table_properties_t*>(props.get()));
+const TableProperties* crocksdb_sstfilereader_get_table_properties(
+    const crocksdb_sstfilereader_t* reader) {
+  return reader->rep->GetTableProperties().get();
 }
 
 void crocksdb_sstfilereader_verify_checksum(crocksdb_sstfilereader_t* reader,
@@ -4543,15 +4532,9 @@ void crocksdb_get_supported_compression(CompressionType* v, size_t l) {
 
 /* Table Properties */
 
-struct crocksdb_user_collected_properties_t {
-  UserCollectedProperties rep;
-};
-
-void crocksdb_user_collected_properties_add(
-    crocksdb_user_collected_properties_t* props, const char* k, size_t klen,
-    const char* v, size_t vlen) {
-  props->rep.emplace(
-      std::make_pair(std::string(k, klen), std::string(v, vlen)));
+void crocksdb_user_collected_properties_add(UserCollectedProperties* props,
+                                            Slice key, Slice value) {
+  props->emplace(std::make_pair(key.ToString(), value.ToString()));
 }
 
 struct crocksdb_user_collected_properties_iterator_t {
@@ -4561,10 +4544,10 @@ struct crocksdb_user_collected_properties_iterator_t {
 
 crocksdb_user_collected_properties_iterator_t*
 crocksdb_user_collected_properties_iter_create(
-    const crocksdb_user_collected_properties_t* props) {
+    const UserCollectedProperties* props) {
   auto it = new crocksdb_user_collected_properties_iterator_t;
-  it->cur_ = props->rep.begin();
-  it->end_ = props->rep.end();
+  it->cur_ = props->begin();
+  it->end_ = props->end();
   return it;
 }
 
@@ -4573,128 +4556,176 @@ void crocksdb_user_collected_properties_iter_destroy(
   delete it;
 }
 
-unsigned char crocksdb_user_collected_properties_iter_valid(
-    const crocksdb_user_collected_properties_iterator_t* it) {
-  return it->cur_ != it->end_;
-}
-
-void crocksdb_user_collected_properties_iter_next(
-    crocksdb_user_collected_properties_iterator_t* it) {
-  ++(it->cur_);
-}
-
-const char* crocksdb_user_collected_properties_iter_key(
-    const crocksdb_user_collected_properties_iterator_t* it, size_t* klen) {
-  *klen = it->cur_->first.size();
-  return it->cur_->first.data();
-}
-
-const char* crocksdb_user_collected_properties_iter_value(
-    const crocksdb_user_collected_properties_iterator_t* it, size_t* vlen) {
-  *vlen = it->cur_->second.size();
-  return it->cur_->second.data();
-}
-
-struct crocksdb_table_properties_t {
-  const TableProperties rep;
-};
-
-uint64_t crocksdb_table_properties_get_u64(
-    const crocksdb_table_properties_t* props, crocksdb_table_property_t prop) {
-  const TableProperties& rep = props->rep;
-  switch (prop) {
-    case kDataSize:
-      return rep.data_size;
-    case kIndexSize:
-      return rep.index_size;
-    case kFilterSize:
-      return rep.filter_size;
-    case kRawKeySize:
-      return rep.raw_key_size;
-    case kRawValueSize:
-      return rep.raw_value_size;
-    case kNumDataBlocks:
-      return rep.num_data_blocks;
-    case kNumEntries:
-      return rep.num_entries;
-    case kFormatVersion:
-      return rep.format_version;
-    case kFixedKeyLen:
-      return rep.data_size;
-    case kColumnFamilyID:
-      return rep.column_family_id;
-    default:
-      return 0;
+bool crocksdb_user_collected_properties_iter_next(
+    crocksdb_user_collected_properties_iterator_t* it, Slice* key, Slice* val) {
+  if (it->cur_ != it->end_) {
+    *key = it->cur_->first;
+    *val = it->cur_->second;
+    ++(it->cur_);
+    return true;
   }
+  return false;
 }
 
-const char* crocksdb_table_properties_get_str(
-    const crocksdb_table_properties_t* props, crocksdb_table_property_t prop,
-    size_t* slen) {
-  const TableProperties& rep = props->rep;
-  switch (prop) {
-    case kColumnFamilyName:
-      *slen = rep.column_family_name.size();
-      return rep.column_family_name.data();
-    case kFilterPolicyName:
-      *slen = rep.filter_policy_name.size();
-      return rep.filter_policy_name.data();
-    case kComparatorName:
-      *slen = rep.comparator_name.size();
-      return rep.comparator_name.data();
-    case kMergeOperatorName:
-      *slen = rep.merge_operator_name.size();
-      return rep.merge_operator_name.data();
-    case kPrefixExtractorName:
-      *slen = rep.prefix_extractor_name.size();
-      return rep.prefix_extractor_name.data();
-    case kPropertyCollectorsNames:
-      *slen = rep.property_collectors_names.size();
-      return rep.property_collectors_names.data();
-    case kCompressionName:
-      *slen = rep.compression_name.size();
-      return rep.compression_name.data();
-    default:
-      return nullptr;
+uint64_t crocksdb_table_properties_get_data_size(const TableProperties* props) {
+  return props->data_size;
+}
+uint64_t crocksdb_table_properties_get_index_size(
+    const TableProperties* props) {
+  return props->index_size;
+}
+uint64_t crocksdb_table_properties_get_index_partitions(
+    const TableProperties* props) {
+  return props->index_partitions;
+}
+uint64_t crocksdb_table_properties_get_top_level_index_size(
+    const TableProperties* props) {
+  return props->top_level_index_size;
+}
+uint64_t crocksdb_table_properties_get_index_key_is_user_key(
+    const TableProperties* props) {
+  return props->index_key_is_user_key;
+}
+uint64_t crocksdb_table_properties_get_index_value_is_delta_encoded(
+    const TableProperties* props) {
+  return props->index_value_is_delta_encoded;
+}
+uint64_t crocksdb_table_properties_get_filter_size(
+    const TableProperties* props) {
+  return props->filter_size;
+}
+uint64_t crocksdb_table_properties_get_raw_key_size(
+    const TableProperties* props) {
+  return props->raw_key_size;
+}
+uint64_t crocksdb_table_properties_get_raw_value_size(
+    const TableProperties* props) {
+  return props->raw_value_size;
+}
+uint64_t crocksdb_table_properties_get_num_data_blocks(
+    const TableProperties* props) {
+  return props->num_data_blocks;
+}
+uint64_t crocksdb_table_properties_get_num_entries(
+    const TableProperties* props) {
+  return props->num_entries;
+}
+uint64_t crocksdb_table_properties_get_num_deletions(
+    const TableProperties* props) {
+  return props->num_deletions;
+}
+uint64_t crocksdb_table_properties_get_num_merge_operands(
+    const TableProperties* props) {
+  return props->num_merge_operands;
+}
+uint64_t crocksdb_table_properties_get_num_range_deletions(
+    const TableProperties* props) {
+  return props->num_range_deletions;
+}
+uint64_t crocksdb_table_properties_get_format_version(
+    const TableProperties* props) {
+  return props->format_version;
+}
+uint64_t crocksdb_table_properties_get_fixed_key_len(
+    const TableProperties* props) {
+  return props->fixed_key_len;
+}
+uint64_t crocksdb_table_properties_get_column_family_id(
+    const TableProperties* props) {
+  return props->column_family_id;
+}
+uint64_t crocksdb_table_properties_get_creation_time(
+    const TableProperties* props) {
+  return props->creation_time;
+}
+uint64_t crocksdb_table_properties_get_oldest_key_time(
+    const TableProperties* props) {
+  return props->oldest_key_time;
+}
+uint64_t crocksdb_table_properties_get_file_creation_time(
+    const TableProperties* props) {
+  return props->file_creation_time;
+}
+
+void crocksdb_table_properties_get_column_family_name(
+    const TableProperties* props, Slice* val) {
+  *val = props->column_family_name;
+}
+void crocksdb_table_properties_get_filter_policy_name(
+    const TableProperties* props, Slice* val) {
+  *val = props->filter_policy_name;
+}
+void crocksdb_table_properties_get_comparator_name(const TableProperties* props,
+                                                   Slice* val) {
+  *val = props->comparator_name;
+}
+void crocksdb_table_properties_get_merge_operator_name(
+    const TableProperties* props, Slice* val) {
+  *val = props->merge_operator_name;
+}
+void crocksdb_table_properties_get_prefix_extractor_name(
+    const TableProperties* props, Slice* val) {
+  *val = props->prefix_extractor_name;
+}
+void crocksdb_table_properties_get_property_collectors_names(
+    const TableProperties* props, Slice* val) {
+  *val = props->property_collectors_names;
+}
+void crocksdb_table_properties_get_compression_name(
+    const TableProperties* props, Slice* val) {
+  *val = props->compression_name;
+}
+void crocksdb_table_properties_get_compression_options(
+    const TableProperties* props, Slice* val) {
+  *val = props->compression_options;
+}
+
+char* crocksdb_table_properties_to_string(const TableProperties* props,
+                                          size_t* len) {
+  auto s = props->ToString();
+  *len = s.size();
+  return strndup(s.data(), s.size());
+}
+
+const UserCollectedProperties* crocksdb_table_properties_get_user_properties(
+    const TableProperties* props) {
+  return &props->user_collected_properties;
+}
+
+bool crocksdb_user_collected_properties_get(
+    const UserCollectedProperties* props, Slice key, Slice* value) {
+  auto val = props->find(key.ToString());
+  if (val == props->end()) {
+    return false;
   }
-}
-
-const crocksdb_user_collected_properties_t*
-crocksdb_table_properties_get_user_properties(
-    const crocksdb_table_properties_t* props) {
-  return reinterpret_cast<const crocksdb_user_collected_properties_t*>(
-      &props->rep.user_collected_properties);
-}
-
-const char* crocksdb_user_collected_properties_get(
-    const crocksdb_user_collected_properties_t* props, const char* key,
-    size_t klen, size_t* vlen) {
-  auto val = props->rep.find(std::string(key, klen));
-  if (val == props->rep.end()) {
-    return nullptr;
-  }
-  *vlen = val->second.size();
-  return val->second.data();
+  *value = val->second;
+  return true;
 }
 
 size_t crocksdb_user_collected_properties_len(
-    const crocksdb_user_collected_properties_t* props) {
-  return props->rep.size();
+    const UserCollectedProperties* props) {
+  return props->size();
 }
 
 /* Table Properties Collection */
 
-struct crocksdb_table_properties_collection_t {
-  TablePropertiesCollection rep_;
-};
+const TableProperties* crocksdb_table_properties_collection_get(
+    const TablePropertiesCollection* props, Slice key) {
+  auto val = props->find(key.ToString());
+  if (val != props->end()) {
+    return val->second.get();
+  } else {
+    return nullptr;
+  }
+}
 
 size_t crocksdb_table_properties_collection_len(
-    const crocksdb_table_properties_collection_t* props) {
-  return props->rep_.size();
+    const TablePropertiesCollection* props) {
+  return props->size();
 }
 
 void crocksdb_table_properties_collection_destroy(
-    crocksdb_table_properties_collection_t* t) {
+    TablePropertiesCollection* t) {
   delete t;
 }
 
@@ -4705,10 +4736,10 @@ struct crocksdb_table_properties_collection_iterator_t {
 
 crocksdb_table_properties_collection_iterator_t*
 crocksdb_table_properties_collection_iter_create(
-    const crocksdb_table_properties_collection_t* collection) {
+    const TablePropertiesCollection* collection) {
   auto it = new crocksdb_table_properties_collection_iterator_t;
-  it->cur_ = collection->rep_.begin();
-  it->end_ = collection->rep_.end();
+  it->cur_ = collection->begin();
+  it->end_ = collection->end();
   return it;
 }
 
@@ -4717,31 +4748,16 @@ void crocksdb_table_properties_collection_iter_destroy(
   delete it;
 }
 
-unsigned char crocksdb_table_properties_collection_iter_valid(
-    const crocksdb_table_properties_collection_iterator_t* it) {
-  return it->cur_ != it->end_;
-}
-
-void crocksdb_table_properties_collection_iter_next(
-    crocksdb_table_properties_collection_iterator_t* it) {
-  ++(it->cur_);
-}
-
-const char* crocksdb_table_properties_collection_iter_key(
-    const crocksdb_table_properties_collection_iterator_t* it, size_t* klen) {
-  *klen = it->cur_->first.size();
-  return it->cur_->first.data();
-}
-
-const crocksdb_table_properties_t*
-crocksdb_table_properties_collection_iter_value(
-    const crocksdb_table_properties_collection_iterator_t* it) {
-  if (it->cur_->second) {
-    return reinterpret_cast<const crocksdb_table_properties_t*>(
-        it->cur_->second.get());
-  } else {
-    return nullptr;
+bool crocksdb_table_properties_collection_iter_next(
+    crocksdb_table_properties_collection_iterator_t* it, Slice* key,
+    const TableProperties** val) {
+  if (it->cur_ != it->end_) {
+    *key = it->cur_->first;
+    *val = it->cur_->second.get();
+    ++(it->cur_);
+    return true;
   }
+  return false;
 }
 
 /* Table Properties Collector */
@@ -4750,25 +4766,24 @@ struct crocksdb_table_properties_collector_t : public TablePropertiesCollector {
   void* state_;
   const char* (*name_)(void*);
   void (*destruct_)(void*);
-  void (*add_)(void*, const char* key, size_t key_len, const char* value,
-               size_t value_len, int entry_type, uint64_t seq,
-               uint64_t file_size);
-  void (*finish_)(void*, crocksdb_user_collected_properties_t* props);
+  void (*add_)(void*, Slice key, Slice value, EntryType entry_type,
+               SequenceNumber seq, uint64_t file_size, Status* s);
+  void (*finish_)(void*, UserCollectedProperties* props, Status*);
 
   virtual ~crocksdb_table_properties_collector_t() { destruct_(state_); }
 
   virtual Status AddUserKey(const Slice& key, const Slice& value,
                             EntryType entry_type, SequenceNumber seq,
                             uint64_t file_size) override {
-    add_(state_, key.data(), key.size(), value.data(), value.size(), entry_type,
-         seq, file_size);
-    return Status::OK();
+    Status s;
+    add_(state_, key, value, entry_type, seq, file_size, &s);
+    return s;
   }
 
   virtual Status Finish(UserCollectedProperties* rep) override {
-    finish_(state_,
-            reinterpret_cast<crocksdb_user_collected_properties_t*>(rep));
-    return Status::OK();
+    Status s;
+    finish_(state_, rep, &s);
+    return s;
   }
 
   virtual UserCollectedProperties GetReadableProperties() const override {
@@ -4783,10 +4798,9 @@ struct crocksdb_table_properties_collector_t : public TablePropertiesCollector {
 crocksdb_table_properties_collector_t*
 crocksdb_table_properties_collector_create(
     void* state, const char* (*name)(void*), void (*destruct)(void*),
-    void (*add)(void*, const char* key, size_t key_len, const char* value,
-                size_t value_len, int entry_type, uint64_t seq,
-                uint64_t file_size),
-    void (*finish)(void*, crocksdb_user_collected_properties_t* props)) {
+    void (*add)(void*, Slice key, Slice value, EntryType entry_type,
+                SequenceNumber seq, uint64_t file_size, Status*),
+    void (*finish)(void*, UserCollectedProperties*, Status*)) {
   auto c = new crocksdb_table_properties_collector_t;
   c->state_ = state;
   c->name_ = name;
@@ -4809,7 +4823,7 @@ struct crocksdb_table_properties_collector_factory_t
   const char* (*name_)(void*);
   void (*destruct_)(void*);
   crocksdb_table_properties_collector_t* (*create_table_properties_collector_)(
-      void*, uint32_t cf);
+      void*, TablePropertiesCollectorFactory::Context context);
 
   virtual ~crocksdb_table_properties_collector_factory_t() {
     destruct_(state_);
@@ -4817,7 +4831,7 @@ struct crocksdb_table_properties_collector_factory_t
 
   virtual TablePropertiesCollector* CreateTablePropertiesCollector(
       TablePropertiesCollectorFactory::Context ctx) override {
-    return create_table_properties_collector_(state_, ctx.column_family_id);
+    return create_table_properties_collector_(state_, ctx);
   }
 
   const char* Name() const override { return name_(state_); }
@@ -4827,7 +4841,7 @@ crocksdb_table_properties_collector_factory_t*
 crocksdb_table_properties_collector_factory_create(
     void* state, const char* (*name)(void*), void (*destruct)(void*),
     crocksdb_table_properties_collector_t* (*create_table_properties_collector)(
-        void*, uint32_t cf)) {
+        void*, TablePropertiesCollectorFactory::Context context)) {
   auto f = new crocksdb_table_properties_collector_factory_t;
   f->state_ = state;
   f->name_ = name;
@@ -4857,10 +4871,10 @@ void crocksdb_options_set_compact_on_deletion(crocksdb_options_t* opt,
 
 /* Get Table Properties */
 
-crocksdb_table_properties_collection_t* crocksdb_get_properties_of_all_tables(
-    crocksdb_t* db, Status* s) {
-  auto v = new crocksdb_table_properties_collection_t;
-  *s = db->rep->GetPropertiesOfAllTables(&v->rep_);
+TablePropertiesCollection* crocksdb_get_properties_of_all_tables(crocksdb_t* db,
+                                                                 Status* s) {
+  auto v = new TablePropertiesCollection;
+  *s = db->rep->GetPropertiesOfAllTables(v);
   if (s->ok()) {
     return v;
   } else {
@@ -4869,12 +4883,10 @@ crocksdb_table_properties_collection_t* crocksdb_get_properties_of_all_tables(
   }
 }
 
-crocksdb_table_properties_collection_t*
-crocksdb_get_properties_of_all_tables_cf(crocksdb_t* db,
-                                         crocksdb_column_family_handle_t* cf,
-                                         Status* s) {
-  auto v = new crocksdb_table_properties_collection_t;
-  *s = db->rep->GetPropertiesOfAllTables(cf->rep, &v->rep_);
+TablePropertiesCollection* crocksdb_get_properties_of_all_tables_cf(
+    crocksdb_t* db, crocksdb_column_family_handle_t* cf, Status* s) {
+  auto v = new TablePropertiesCollection;
+  *s = db->rep->GetPropertiesOfAllTables(cf->rep, v);
   if (s->ok()) {
     return v;
   } else {
@@ -4883,8 +4895,7 @@ crocksdb_get_properties_of_all_tables_cf(crocksdb_t* db,
   }
 }
 
-crocksdb_table_properties_collection_t*
-crocksdb_get_properties_of_tables_in_range(
+TablePropertiesCollection* crocksdb_get_properties_of_tables_in_range(
     crocksdb_t* db, crocksdb_column_family_handle_t* cf, int num_ranges,
     const char* const* start_keys, const size_t* start_keys_lens,
     const char* const* limit_keys, const size_t* limit_keys_lens, Status* s) {
@@ -4893,9 +4904,9 @@ crocksdb_get_properties_of_tables_in_range(
     ranges.emplace_back(Range(Slice(start_keys[i], start_keys_lens[i]),
                               Slice(limit_keys[i], limit_keys_lens[i])));
   }
-  auto v = new crocksdb_table_properties_collection_t;
+  auto v = new TablePropertiesCollection;
   *s = db->rep->GetPropertiesOfTablesInRange(cf->rep, ranges.data(),
-                                             ranges.size(), &v->rep_);
+                                             ranges.size(), v);
   if (s->ok()) {
     return v;
   } else {

--- a/tirocks-sys/crocksdb/crocksdb/c.h
+++ b/tirocks-sys/crocksdb/crocksdb/c.h
@@ -1921,7 +1921,7 @@ extern C_ROCKSDB_LIBRARY_API crocksdb_table_properties_collector_factory_t*
 crocksdb_table_properties_collector_factory_create(
     void* state, const char* (*name)(void*), void (*destruct)(void*),
     crocksdb_table_properties_collector_t* (*create_table_properties_collector)(
-        void*, TablePropertiesCollectorFactory::Context context));
+        void*, uint32_t column_family_id));
 
 extern C_ROCKSDB_LIBRARY_API void
 crocksdb_table_properties_collector_factory_destroy(

--- a/tirocks-sys/crocksdb/crocksdb/c.h
+++ b/tirocks-sys/crocksdb/crocksdb/c.h
@@ -123,13 +123,8 @@ typedef struct crocksdb_sstfilewriter_t crocksdb_sstfilewriter_t;
 typedef struct crocksdb_externalsstfileinfo_t crocksdb_externalsstfileinfo_t;
 typedef struct crocksdb_ratelimiter_t crocksdb_ratelimiter_t;
 typedef struct crocksdb_pinnableslice_t crocksdb_pinnableslice_t;
-typedef struct crocksdb_user_collected_properties_t
-    crocksdb_user_collected_properties_t;
 typedef struct crocksdb_user_collected_properties_iterator_t
     crocksdb_user_collected_properties_iterator_t;
-typedef struct crocksdb_table_properties_t crocksdb_table_properties_t;
-typedef struct crocksdb_table_properties_collection_t
-    crocksdb_table_properties_collection_t;
 typedef struct crocksdb_table_properties_collection_iterator_t
     crocksdb_table_properties_collection_iterator_t;
 typedef struct crocksdb_table_properties_collector_t
@@ -211,26 +206,6 @@ typedef struct crocksdb_sst_partitioner_context_t
     crocksdb_sst_partitioner_context_t;
 typedef struct crocksdb_sst_partitioner_factory_t
     crocksdb_sst_partitioner_factory_t;
-
-typedef enum crocksdb_table_property_t {
-  kDataSize = 1,
-  kIndexSize = 2,
-  kFilterSize = 3,
-  kRawKeySize = 4,
-  kRawValueSize = 5,
-  kNumDataBlocks = 6,
-  kNumEntries = 7,
-  kFormatVersion = 8,
-  kFixedKeyLen = 9,
-  kColumnFamilyID = 10,
-  kColumnFamilyName = 11,
-  kFilterPolicyName = 12,
-  kComparatorName = 13,
-  kMergeOperatorName = 14,
-  kPrefixExtractorName = 15,
-  kPropertyCollectorsNames = 16,
-  kCompressionName = 17,
-} crocksdb_table_property_t;
 
 #ifdef OPENSSL
 typedef struct crocksdb_file_encryption_info_t crocksdb_file_encryption_info_t;
@@ -810,7 +785,7 @@ extern C_ROCKSDB_LIBRARY_API const char* crocksdb_flushjobinfo_cf_name(
     const crocksdb_flushjobinfo_t*, size_t*);
 extern C_ROCKSDB_LIBRARY_API const char* crocksdb_flushjobinfo_file_path(
     const crocksdb_flushjobinfo_t*, size_t*);
-extern C_ROCKSDB_LIBRARY_API const crocksdb_table_properties_t*
+extern C_ROCKSDB_LIBRARY_API const TableProperties*
 crocksdb_flushjobinfo_table_properties(const crocksdb_flushjobinfo_t*);
 extern C_ROCKSDB_LIBRARY_API unsigned char
 crocksdb_flushjobinfo_triggered_writes_slowdown(const crocksdb_flushjobinfo_t*);
@@ -834,7 +809,7 @@ crocksdb_compactionjobinfo_output_files_count(
 extern C_ROCKSDB_LIBRARY_API const char*
 crocksdb_compactionjobinfo_output_file_at(const crocksdb_compactionjobinfo_t*,
                                           size_t pos, size_t*);
-extern C_ROCKSDB_LIBRARY_API const crocksdb_table_properties_collection_t*
+extern C_ROCKSDB_LIBRARY_API const TablePropertiesCollection*
 crocksdb_compactionjobinfo_table_properties(
     const crocksdb_compactionjobinfo_t*);
 extern C_ROCKSDB_LIBRARY_API uint64_t
@@ -881,7 +856,7 @@ crocksdb_externalfileingestioninfo_cf_name(
 extern C_ROCKSDB_LIBRARY_API const char*
 crocksdb_externalfileingestioninfo_internal_file_path(
     const crocksdb_externalfileingestioninfo_t*, size_t*);
-extern C_ROCKSDB_LIBRARY_API const crocksdb_table_properties_t*
+extern C_ROCKSDB_LIBRARY_API const TableProperties*
 crocksdb_externalfileingestioninfo_table_properties(
     const crocksdb_externalfileingestioninfo_t*);
 extern C_ROCKSDB_LIBRARY_API const int
@@ -983,8 +958,6 @@ extern C_ROCKSDB_LIBRARY_API void crocksdb_options_set_compaction_filter(
 extern C_ROCKSDB_LIBRARY_API void
 crocksdb_options_set_compaction_filter_factory(
     crocksdb_options_t*, crocksdb_compactionfilterfactory_t*);
-extern C_ROCKSDB_LIBRARY_API void crocksdb_options_compaction_readahead_size(
-    crocksdb_options_t*, size_t);
 extern C_ROCKSDB_LIBRARY_API void crocksdb_options_set_comparator(
     crocksdb_options_t*, crocksdb_comparator_t*);
 extern C_ROCKSDB_LIBRARY_API void crocksdb_options_set_merge_operator(
@@ -1375,7 +1348,7 @@ extern C_ROCKSDB_LIBRARY_API void crocksdb_compactionfiltercontext_file_numbers(
     crocksdb_compactionfiltercontext_t* context, const uint64_t** buffer,
     size_t* len);
 
-extern C_ROCKSDB_LIBRARY_API crocksdb_table_properties_t*
+extern C_ROCKSDB_LIBRARY_API const TableProperties*
 crocksdb_compactionfiltercontext_table_properties(
     crocksdb_compactionfiltercontext_t* context, size_t offset);
 
@@ -1445,7 +1418,7 @@ extern C_ROCKSDB_LIBRARY_API void crocksdb_mergeoperator_destroy(
 /* Read options */
 extern C_ROCKSDB_LIBRARY_API void crocksdb_readoptions_set_table_filter(
     ReadOptions*, void*,
-    unsigned char (*table_filter)(void*, const crocksdb_table_properties_t*),
+    unsigned char (*table_filter)(void*, const TableProperties*),
     void (*destory)(void*));
 
 /* Write options */
@@ -1617,9 +1590,9 @@ extern C_ROCKSDB_LIBRARY_API crocksdb_iterator_t*
 crocksdb_sstfilereader_new_iterator(crocksdb_sstfilereader_t* reader,
                                     const ReadOptions* options);
 
-extern C_ROCKSDB_LIBRARY_API void crocksdb_sstfilereader_read_table_properties(
-    const crocksdb_sstfilereader_t* reader, void* ctx,
-    void (*cb)(void*, const crocksdb_table_properties_t*));
+extern C_ROCKSDB_LIBRARY_API const TableProperties*
+crocksdb_sstfilereader_get_table_properties(
+    const crocksdb_sstfilereader_t* reader);
 
 extern C_ROCKSDB_LIBRARY_API void crocksdb_sstfilereader_verify_checksum(
     crocksdb_sstfilereader_t* reader, Status* s);
@@ -1814,92 +1787,130 @@ extern C_ROCKSDB_LIBRARY_API void crocksdb_get_supported_compression(
 
 /* Table Properties */
 
-extern C_ROCKSDB_LIBRARY_API uint64_t crocksdb_table_properties_get_u64(
-    const crocksdb_table_properties_t*, crocksdb_table_property_t prop);
+extern C_ROCKSDB_LIBRARY_API uint64_t
+crocksdb_table_properties_get_data_size(const TableProperties*);
+extern C_ROCKSDB_LIBRARY_API uint64_t
+crocksdb_table_properties_get_index_size(const TableProperties*);
+extern C_ROCKSDB_LIBRARY_API uint64_t
+crocksdb_table_properties_get_index_partitions(const TableProperties*);
+extern C_ROCKSDB_LIBRARY_API uint64_t
+crocksdb_table_properties_get_top_level_index_size(const TableProperties*);
+extern C_ROCKSDB_LIBRARY_API uint64_t
+crocksdb_table_properties_get_index_key_is_user_key(const TableProperties*);
+extern C_ROCKSDB_LIBRARY_API uint64_t
+crocksdb_table_properties_get_index_value_is_delta_encoded(
+    const TableProperties*);
+extern C_ROCKSDB_LIBRARY_API uint64_t
+crocksdb_table_properties_get_filter_size(const TableProperties*);
+extern C_ROCKSDB_LIBRARY_API uint64_t
+crocksdb_table_properties_get_raw_key_size(const TableProperties*);
+extern C_ROCKSDB_LIBRARY_API uint64_t
+crocksdb_table_properties_get_raw_value_size(const TableProperties*);
+extern C_ROCKSDB_LIBRARY_API uint64_t
+crocksdb_table_properties_get_num_data_blocks(const TableProperties*);
+extern C_ROCKSDB_LIBRARY_API uint64_t
+crocksdb_table_properties_get_num_entries(const TableProperties*);
+extern C_ROCKSDB_LIBRARY_API uint64_t
+crocksdb_table_properties_get_num_deletions(const TableProperties*);
+extern C_ROCKSDB_LIBRARY_API uint64_t
+crocksdb_table_properties_get_num_merge_operands(const TableProperties*);
+extern C_ROCKSDB_LIBRARY_API uint64_t
+crocksdb_table_properties_get_num_range_deletions(const TableProperties*);
+extern C_ROCKSDB_LIBRARY_API uint64_t
+crocksdb_table_properties_get_format_version(const TableProperties*);
+extern C_ROCKSDB_LIBRARY_API uint64_t
+crocksdb_table_properties_get_fixed_key_len(const TableProperties*);
+extern C_ROCKSDB_LIBRARY_API uint64_t
+crocksdb_table_properties_get_column_family_id(const TableProperties*);
+extern C_ROCKSDB_LIBRARY_API uint64_t
+crocksdb_table_properties_get_creation_time(const TableProperties*);
+extern C_ROCKSDB_LIBRARY_API uint64_t
+crocksdb_table_properties_get_oldest_key_time(const TableProperties*);
+extern C_ROCKSDB_LIBRARY_API uint64_t
+crocksdb_table_properties_get_file_creation_time(const TableProperties*);
 
-extern C_ROCKSDB_LIBRARY_API const char* crocksdb_table_properties_get_str(
-    const crocksdb_table_properties_t*, crocksdb_table_property_t prop,
-    size_t* slen);
+extern C_ROCKSDB_LIBRARY_API void
+crocksdb_table_properties_get_column_family_name(const TableProperties*,
+                                                 Slice* val);
+extern C_ROCKSDB_LIBRARY_API void
+crocksdb_table_properties_get_filter_policy_name(const TableProperties*,
+                                                 Slice* val);
+extern C_ROCKSDB_LIBRARY_API void crocksdb_table_properties_get_comparator_name(
+    const TableProperties*, Slice* val);
+extern C_ROCKSDB_LIBRARY_API void
+crocksdb_table_properties_get_merge_operator_name(const TableProperties*,
+                                                  Slice* val);
+extern C_ROCKSDB_LIBRARY_API void
+crocksdb_table_properties_get_prefix_extractor_name(const TableProperties*,
+                                                    Slice* val);
+extern C_ROCKSDB_LIBRARY_API void
+crocksdb_table_properties_get_property_collectors_names(const TableProperties*,
+                                                        Slice* val);
+extern C_ROCKSDB_LIBRARY_API void
+crocksdb_table_properties_get_compression_name(const TableProperties*,
+                                               Slice* val);
+extern C_ROCKSDB_LIBRARY_API void
+crocksdb_table_properties_get_compression_options(const TableProperties*,
+                                                  Slice* val);
 
-extern C_ROCKSDB_LIBRARY_API const crocksdb_user_collected_properties_t*
-crocksdb_table_properties_get_user_properties(
-    const crocksdb_table_properties_t*);
+extern C_ROCKSDB_LIBRARY_API char* crocksdb_table_properties_to_string(
+    const TableProperties*, size_t* len);
 
-extern C_ROCKSDB_LIBRARY_API const char* crocksdb_user_collected_properties_get(
-    const crocksdb_user_collected_properties_t* props, const char* key,
-    size_t klen, size_t* vlen);
+extern C_ROCKSDB_LIBRARY_API const UserCollectedProperties*
+crocksdb_table_properties_get_user_properties(const TableProperties*);
 
-extern C_ROCKSDB_LIBRARY_API size_t crocksdb_user_collected_properties_len(
-    const crocksdb_user_collected_properties_t*);
+extern C_ROCKSDB_LIBRARY_API bool crocksdb_user_collected_properties_get(
+    const UserCollectedProperties* props, Slice zkey, Slice* value);
+
+extern C_ROCKSDB_LIBRARY_API size_t
+crocksdb_user_collected_properties_len(const UserCollectedProperties*);
 
 extern C_ROCKSDB_LIBRARY_API void crocksdb_user_collected_properties_add(
-    crocksdb_user_collected_properties_t*, const char* key, size_t key_len,
-    const char* value, size_t value_len);
+    UserCollectedProperties*, Slice key, Slice value);
 
 extern C_ROCKSDB_LIBRARY_API crocksdb_user_collected_properties_iterator_t*
-crocksdb_user_collected_properties_iter_create(
-    const crocksdb_user_collected_properties_t*);
+crocksdb_user_collected_properties_iter_create(const UserCollectedProperties*);
 
 extern C_ROCKSDB_LIBRARY_API void
 crocksdb_user_collected_properties_iter_destroy(
     crocksdb_user_collected_properties_iterator_t*);
 
-extern C_ROCKSDB_LIBRARY_API unsigned char
-crocksdb_user_collected_properties_iter_valid(
-    const crocksdb_user_collected_properties_iterator_t*);
-
-extern C_ROCKSDB_LIBRARY_API void crocksdb_user_collected_properties_iter_next(
-    crocksdb_user_collected_properties_iterator_t*);
-
-extern C_ROCKSDB_LIBRARY_API const char*
-crocksdb_user_collected_properties_iter_key(
-    const crocksdb_user_collected_properties_iterator_t*, size_t* klen);
-
-extern C_ROCKSDB_LIBRARY_API const char*
-crocksdb_user_collected_properties_iter_value(
-    const crocksdb_user_collected_properties_iterator_t*, size_t* vlen);
+extern C_ROCKSDB_LIBRARY_API bool crocksdb_user_collected_properties_iter_next(
+    crocksdb_user_collected_properties_iterator_t*, Slice* key, Slice* val);
 
 /* Table Properties Collection */
 
-extern C_ROCKSDB_LIBRARY_API size_t crocksdb_table_properties_collection_len(
-    const crocksdb_table_properties_collection_t*);
+extern C_ROCKSDB_LIBRARY_API const TableProperties*
+crocksdb_table_properties_collection_get(const TablePropertiesCollection*,
+                                         Slice);
+
+extern C_ROCKSDB_LIBRARY_API size_t
+crocksdb_table_properties_collection_len(const TablePropertiesCollection*);
 
 extern C_ROCKSDB_LIBRARY_API void crocksdb_table_properties_collection_destroy(
-    crocksdb_table_properties_collection_t*);
+    TablePropertiesCollection*);
 
 extern C_ROCKSDB_LIBRARY_API crocksdb_table_properties_collection_iterator_t*
 crocksdb_table_properties_collection_iter_create(
-    const crocksdb_table_properties_collection_t*);
+    const TablePropertiesCollection*);
 
 extern C_ROCKSDB_LIBRARY_API void
 crocksdb_table_properties_collection_iter_destroy(
     crocksdb_table_properties_collection_iterator_t*);
 
-extern C_ROCKSDB_LIBRARY_API unsigned char
-crocksdb_table_properties_collection_iter_valid(
-    const crocksdb_table_properties_collection_iterator_t*);
-
-extern C_ROCKSDB_LIBRARY_API void
+extern C_ROCKSDB_LIBRARY_API bool
 crocksdb_table_properties_collection_iter_next(
-    crocksdb_table_properties_collection_iterator_t*);
-
-extern C_ROCKSDB_LIBRARY_API const char*
-crocksdb_table_properties_collection_iter_key(
-    const crocksdb_table_properties_collection_iterator_t*, size_t* klen);
-
-extern C_ROCKSDB_LIBRARY_API const crocksdb_table_properties_t*
-crocksdb_table_properties_collection_iter_value(
-    const crocksdb_table_properties_collection_iterator_t*);
+    crocksdb_table_properties_collection_iterator_t*, Slice* key,
+    const TableProperties** val);
 
 /* Table Properties Collector */
 
 extern C_ROCKSDB_LIBRARY_API crocksdb_table_properties_collector_t*
 crocksdb_table_properties_collector_create(
     void* state, const char* (*name)(void*), void (*destruct)(void*),
-    void (*add)(void*, const char* key, size_t key_len, const char* value,
-                size_t value_len, int entry_type, uint64_t seq,
-                uint64_t file_size),
-    void (*finish)(void*, crocksdb_user_collected_properties_t* props));
+    void (*add)(void*, Slice key, Slice value, EntryType entry_type,
+                SequenceNumber seq, uint64_t file_size, Status*),
+    void (*finish)(void*, UserCollectedProperties*, Status*));
 
 extern C_ROCKSDB_LIBRARY_API void crocksdb_table_properties_collector_destroy(
     crocksdb_table_properties_collector_t*);
@@ -1910,7 +1921,7 @@ extern C_ROCKSDB_LIBRARY_API crocksdb_table_properties_collector_factory_t*
 crocksdb_table_properties_collector_factory_create(
     void* state, const char* (*name)(void*), void (*destruct)(void*),
     crocksdb_table_properties_collector_t* (*create_table_properties_collector)(
-        void*, uint32_t cf));
+        void*, TablePropertiesCollectorFactory::Context context));
 
 extern C_ROCKSDB_LIBRARY_API void
 crocksdb_table_properties_collector_factory_destroy(
@@ -1925,15 +1936,15 @@ extern C_ROCKSDB_LIBRARY_API void crocksdb_options_set_compact_on_deletion(
     size_t deletion_trigger);
 
 /* Get Table Properties */
-extern C_ROCKSDB_LIBRARY_API crocksdb_table_properties_collection_t*
+extern C_ROCKSDB_LIBRARY_API TablePropertiesCollection*
 crocksdb_get_properties_of_all_tables(crocksdb_t* db, Status* s);
 
-extern C_ROCKSDB_LIBRARY_API crocksdb_table_properties_collection_t*
+extern C_ROCKSDB_LIBRARY_API TablePropertiesCollection*
 crocksdb_get_properties_of_all_tables_cf(crocksdb_t* db,
                                          crocksdb_column_family_handle_t* cf,
                                          Status* s);
 
-extern C_ROCKSDB_LIBRARY_API crocksdb_table_properties_collection_t*
+extern C_ROCKSDB_LIBRARY_API TablePropertiesCollection*
 crocksdb_get_properties_of_tables_in_range(
     crocksdb_t* db, crocksdb_column_family_handle_t* cf, int num_ranges,
     const char* const* start_keys, const size_t* start_keys_lens,

--- a/tirocks-sys/src/lib.rs
+++ b/tirocks-sys/src/lib.rs
@@ -10,6 +10,10 @@ extern crate bzip2_sys;
 
 #[allow(clippy::all)]
 mod bindings {
+    pub enum rocksdb_TableProperties {}
+    pub enum rocksdb_UserCollectedProperties {}
+    pub enum rocksdb_TablePropertiesCollection {}
+
     include!(env!("BINDING_PATH"));
 }
 

--- a/tirocks/src/lib.rs
+++ b/tirocks/src/lib.rs
@@ -6,5 +6,8 @@ pub mod env;
 mod error;
 pub mod option;
 pub mod rate_limiter;
+// TODO: remove this when options are all implemented.
+#[allow(unused)]
+pub mod table_properties;
 
 pub use error::{Code, Result, Severity, Status, SubCode};

--- a/tirocks/src/table_properties.rs
+++ b/tirocks/src/table_properties.rs
@@ -1,0 +1,4 @@
+// Copyright 2022 TiKV Project Authors. Licensed under Apache-2.0.
+
+pub mod builtin;
+pub mod user;

--- a/tirocks/src/table_properties/builtin.rs
+++ b/tirocks/src/table_properties/builtin.rs
@@ -144,7 +144,7 @@ impl TableProperties {
         }
     }
 
-    // Timestamp of the latest key. 0 means unknown.
+    /// Timestamp of the latest key. 0 means unknown.
     #[inline]
     pub fn creation_time(&self) -> u64 {
         unsafe { tirocks_sys::crocksdb_table_properties_get_creation_time(self as *const _ as _) }
@@ -219,8 +219,8 @@ impl TableProperties {
         }
     }
 
-    // The name of the prefix extractor used in this table
-    // If no prefix extractor is used, `prefix_extractor_name` will be "nullptr".
+    /// The name of the prefix extractor used in this table
+    /// If no prefix extractor is used, `prefix_extractor_name` will be "nullptr".
     #[inline]
     pub fn prefix_extractor_name(&self) -> std::result::Result<&str, Utf8Error> {
         unsafe {

--- a/tirocks/src/table_properties/builtin.rs
+++ b/tirocks/src/table_properties/builtin.rs
@@ -1,0 +1,428 @@
+// Copyright 2022 TiKV Project Authors. Licensed under Apache-2.0.
+
+use std::{
+    fmt::{self, Debug, Formatter},
+    marker::PhantomData,
+    ops::Index,
+    ptr::{self, NonNull},
+    slice,
+    str::{self, Utf8Error},
+};
+
+use tirocks_sys::{
+    crocksdb_table_properties_collection_iterator_t, r, rocksdb_TablePropertiesCollection, s,
+};
+
+#[repr(transparent)]
+pub struct TableProperties(tirocks_sys::rocksdb_TableProperties);
+
+impl TableProperties {
+    #[inline]
+    pub(crate) unsafe fn from_ptr<'a>(
+        ptr: *const tirocks_sys::rocksdb_TableProperties,
+    ) -> &'a TableProperties {
+        &*(ptr as *const TableProperties)
+    }
+
+    /// the total size of all data blocks.
+    #[inline]
+    pub fn data_size(&self) -> u64 {
+        unsafe { tirocks_sys::crocksdb_table_properties_get_data_size(self as *const _ as _) }
+    }
+
+    /// the size of index block.
+    #[inline]
+    pub fn index_size(&self) -> u64 {
+        unsafe { tirocks_sys::crocksdb_table_properties_get_index_size(self as *const _ as _) }
+    }
+
+    /// Total number of index partitions if kTwoLevelIndexSearch is used
+    #[inline]
+    pub fn index_partitions(&self) -> u64 {
+        unsafe {
+            tirocks_sys::crocksdb_table_properties_get_index_partitions(self as *const _ as _)
+        }
+    }
+
+    /// Size of the top-level index if kTwoLevelIndexSearch is used
+    #[inline]
+    pub fn top_level_index_size(&self) -> u64 {
+        unsafe {
+            tirocks_sys::crocksdb_table_properties_get_top_level_index_size(self as *const _ as _)
+        }
+    }
+
+    /// Whether the index key is user key. Otherwise it includes 8 byte of sequence
+    /// number added by internal key format.
+    #[inline]
+    pub fn index_key_is_user_key(&self) -> u64 {
+        unsafe {
+            tirocks_sys::crocksdb_table_properties_get_index_key_is_user_key(self as *const _ as _)
+        }
+    }
+
+    /// Whether delta encoding is used to encode the index values.
+    #[inline]
+    pub fn index_value_is_delta_encoded(&self) -> u64 {
+        unsafe {
+            tirocks_sys::crocksdb_table_properties_get_index_value_is_delta_encoded(
+                self as *const _ as _,
+            )
+        }
+    }
+
+    /// the size of filter block.
+    #[inline]
+    pub fn filter_size(&self) -> u64 {
+        unsafe { tirocks_sys::crocksdb_table_properties_get_filter_size(self as *const _ as _) }
+    }
+
+    /// total raw key size
+    #[inline]
+    pub fn raw_key_size(&self) -> u64 {
+        unsafe { tirocks_sys::crocksdb_table_properties_get_raw_key_size(self as *const _ as _) }
+    }
+
+    /// total raw value size
+    #[inline]
+    pub fn raw_value_size(&self) -> u64 {
+        unsafe { tirocks_sys::crocksdb_table_properties_get_raw_value_size(self as *const _ as _) }
+    }
+
+    /// the number of blocks in this table
+    #[inline]
+    pub fn num_data_blocks(&self) -> u64 {
+        unsafe { tirocks_sys::crocksdb_table_properties_get_num_data_blocks(self as *const _ as _) }
+    }
+
+    /// the number of entries in this table
+    #[inline]
+    pub fn num_entries(&self) -> u64 {
+        unsafe { tirocks_sys::crocksdb_table_properties_get_num_entries(self as *const _ as _) }
+    }
+
+    /// the number of deletions in the table
+    #[inline]
+    pub fn num_deletions(&self) -> u64 {
+        unsafe { tirocks_sys::crocksdb_table_properties_get_num_deletions(self as *const _ as _) }
+    }
+
+    /// the number of merge operands in the table
+    #[inline]
+    pub fn num_merge_operands(&self) -> u64 {
+        unsafe {
+            tirocks_sys::crocksdb_table_properties_get_num_merge_operands(self as *const _ as _)
+        }
+    }
+
+    /// the number of range deletions in this table
+    #[inline]
+    pub fn num_range_deletions(&self) -> u64 {
+        unsafe {
+            tirocks_sys::crocksdb_table_properties_get_num_range_deletions(self as *const _ as _)
+        }
+    }
+
+    /// format version, reserved for backward compatibility
+    #[inline]
+    pub fn format_version(&self) -> u64 {
+        unsafe { tirocks_sys::crocksdb_table_properties_get_format_version(self as *const _ as _) }
+    }
+
+    /// If 0, key is variable length. Otherwise number of bytes for each key.
+    #[inline]
+    pub fn fixed_key_len(&self) -> u64 {
+        unsafe { tirocks_sys::crocksdb_table_properties_get_fixed_key_len(self as *const _ as _) }
+    }
+
+    /// ID of column family for this SST file, corresponding to the CF identified
+    /// by column_family_name.
+    #[inline]
+    pub fn column_family_id(&self) -> u64 {
+        unsafe {
+            tirocks_sys::crocksdb_table_properties_get_column_family_id(self as *const _ as _)
+        }
+    }
+
+    // Timestamp of the latest key. 0 means unknown.
+    #[inline]
+    pub fn creation_time(&self) -> u64 {
+        unsafe { tirocks_sys::crocksdb_table_properties_get_creation_time(self as *const _ as _) }
+    }
+
+    /// Timestamp of the earliest key. 0 means unknown.
+    #[inline]
+    pub fn oldest_key_time(&self) -> u64 {
+        unsafe { tirocks_sys::crocksdb_table_properties_get_oldest_key_time(self as *const _ as _) }
+    }
+
+    /// Actual SST file creation time. 0 means unknown.
+    #[inline]
+    pub fn file_creation_time(&self) -> u64 {
+        unsafe {
+            tirocks_sys::crocksdb_table_properties_get_file_creation_time(self as *const _ as _)
+        }
+    }
+
+    /// Name of the column family with which this SST file is associated.
+    /// If column family is unknown, `column_family_name` will be an empty string.
+    #[inline]
+    pub fn column_family_name(&self) -> std::result::Result<&str, Utf8Error> {
+        unsafe {
+            let mut buf = r(&[]);
+            tirocks_sys::crocksdb_table_properties_get_column_family_name(
+                self as *const _ as _,
+                &mut buf,
+            );
+            str::from_utf8(s(buf))
+        }
+    }
+
+    /// The name of the filter policy used in this table.
+    /// If no filter policy is used, `filter_policy_name` will be an empty string.
+    #[inline]
+    pub fn filter_policy_name(&self) -> std::result::Result<&str, Utf8Error> {
+        unsafe {
+            let mut buf = r(&[]);
+            tirocks_sys::crocksdb_table_properties_get_filter_policy_name(
+                self as *const _ as _,
+                &mut buf,
+            );
+            str::from_utf8(s(buf))
+        }
+    }
+
+    /// The name of the comparator used in this table.
+    #[inline]
+    pub fn comparator_name(&self) -> std::result::Result<&str, Utf8Error> {
+        unsafe {
+            let mut buf = r(&[]);
+            tirocks_sys::crocksdb_table_properties_get_comparator_name(
+                self as *const _ as _,
+                &mut buf,
+            );
+            str::from_utf8(s(buf))
+        }
+    }
+
+    /// The name of the merge operator used in this table.
+    /// If no merge operator is used, `merge_operator_name` will be "nullptr".
+    #[inline]
+    pub fn merge_operator_name(&self) -> std::result::Result<&str, Utf8Error> {
+        unsafe {
+            let mut buf = r(&[]);
+            tirocks_sys::crocksdb_table_properties_get_merge_operator_name(
+                self as *const _ as _,
+                &mut buf,
+            );
+            str::from_utf8(s(buf))
+        }
+    }
+
+    // The name of the prefix extractor used in this table
+    // If no prefix extractor is used, `prefix_extractor_name` will be "nullptr".
+    #[inline]
+    pub fn prefix_extractor_name(&self) -> std::result::Result<&str, Utf8Error> {
+        unsafe {
+            let mut buf = r(&[]);
+            tirocks_sys::crocksdb_table_properties_get_prefix_extractor_name(
+                self as *const _ as _,
+                &mut buf,
+            );
+            str::from_utf8(s(buf))
+        }
+    }
+
+    /// The names of the property collectors factories used in this table
+    /// separated by commas
+    /// {collector_name[1]},{collector_name[2]},{collector_name[3]} ..
+    #[inline]
+    pub fn property_collectors_names(&self) -> std::result::Result<&str, Utf8Error> {
+        unsafe {
+            let mut buf = r(&[]);
+            tirocks_sys::crocksdb_table_properties_get_property_collectors_names(
+                self as *const _ as _,
+                &mut buf,
+            );
+            str::from_utf8(s(buf))
+        }
+    }
+
+    /// The compression algo used to compress the SST files.
+    #[inline]
+    pub fn compression_name(&self) -> std::result::Result<&str, Utf8Error> {
+        unsafe {
+            let mut buf = r(&[]);
+            tirocks_sys::crocksdb_table_properties_get_compression_name(
+                self as *const _ as _,
+                &mut buf,
+            );
+            str::from_utf8(s(buf))
+        }
+    }
+
+    /// Compression options used to compress the SST files.
+    #[inline]
+    pub fn compression_options(&self) -> std::result::Result<&str, Utf8Error> {
+        unsafe {
+            let mut buf = r(&[]);
+            tirocks_sys::crocksdb_table_properties_get_compression_options(
+                self as *const _ as _,
+                &mut buf,
+            );
+            str::from_utf8(s(buf))
+        }
+    }
+}
+
+impl Debug for TableProperties {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+        let mut len = 0;
+        unsafe {
+            let s =
+                tirocks_sys::crocksdb_table_properties_to_string(self as *const _ as _, &mut len);
+            let buf = slice::from_raw_parts(s as *mut u8, len);
+            let res = write!(f, "{}", String::from_utf8_lossy(buf));
+            libc::free(s as _);
+            res
+        }
+    }
+}
+
+enum Collection<'a> {
+    Owned(NonNull<rocksdb_TablePropertiesCollection>),
+    Borrowed(&'a rocksdb_TablePropertiesCollection),
+}
+
+pub struct TablePropertiesCollection<'a> {
+    ptr: Collection<'a>,
+}
+
+impl<'a> Drop for TablePropertiesCollection<'a> {
+    #[inline]
+    fn drop(&mut self) {
+        if let Collection::Owned(ptr) = self.ptr {
+            unsafe {
+                let ptr = ptr.as_ptr();
+                tirocks_sys::crocksdb_table_properties_collection_destroy(ptr);
+            }
+        }
+    }
+}
+
+impl<'a> TablePropertiesCollection<'a> {
+    #[inline]
+    pub(crate) unsafe fn from_borrowed(
+        ptr: *const tirocks_sys::rocksdb_TablePropertiesCollection,
+    ) -> Self {
+        Self {
+            ptr: Collection::Borrowed(&*ptr),
+        }
+    }
+
+    #[inline]
+    pub(crate) unsafe fn from_owned(
+        ptr: *mut tirocks_sys::rocksdb_TablePropertiesCollection,
+    ) -> TablePropertiesCollection<'static> {
+        TablePropertiesCollection {
+            ptr: Collection::Owned(NonNull::new_unchecked(ptr)),
+        }
+    }
+
+    #[inline]
+    fn as_ptr(&self) -> *const tirocks_sys::rocksdb_TablePropertiesCollection {
+        match self.ptr {
+            Collection::Borrowed(p) => p,
+            Collection::Owned(p) => p.as_ptr(),
+        }
+    }
+
+    #[inline]
+    pub fn get(&self, index: impl AsRef<[u8]>) -> Option<&TableProperties> {
+        let bytes = index.as_ref();
+        unsafe {
+            let ptr =
+                tirocks_sys::crocksdb_table_properties_collection_get(self.as_ptr(), r(bytes));
+            if !ptr.is_null() {
+                Some(TableProperties::from_ptr(ptr))
+            } else {
+                None
+            }
+        }
+    }
+
+    #[inline]
+    pub fn len(&self) -> usize {
+        unsafe { tirocks_sys::crocksdb_table_properties_collection_len(self.as_ptr()) }
+    }
+
+    #[inline]
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+}
+
+impl<'a, Q: AsRef<[u8]>> Index<Q> for TablePropertiesCollection<'a> {
+    type Output = TableProperties;
+
+    #[inline]
+    fn index(&self, index: Q) -> &TableProperties {
+        let key = index.as_ref();
+        self.get(key)
+            .unwrap_or_else(|| panic!("no entry found for key {:?}", key))
+    }
+}
+
+impl<'a> IntoIterator for &'a TablePropertiesCollection<'_> {
+    type Item = (&'a [u8], &'a TableProperties);
+    type IntoIter = TablePropertiesCollectionIter<'a>;
+
+    #[inline]
+    fn into_iter(self) -> Self::IntoIter {
+        TablePropertiesCollectionIter::new(self)
+    }
+}
+
+pub struct TablePropertiesCollectionIter<'a> {
+    ptr: *mut crocksdb_table_properties_collection_iterator_t,
+    _life: PhantomData<&'a TablePropertiesCollection<'a>>,
+}
+
+impl<'a> Drop for TablePropertiesCollectionIter<'a> {
+    #[inline]
+    fn drop(&mut self) {
+        unsafe {
+            tirocks_sys::crocksdb_table_properties_collection_iter_destroy(self.ptr);
+        }
+    }
+}
+
+impl<'a> TablePropertiesCollectionIter<'a> {
+    #[inline]
+    fn new(props: &'a TablePropertiesCollection) -> TablePropertiesCollectionIter<'a> {
+        unsafe {
+            TablePropertiesCollectionIter {
+                ptr: tirocks_sys::crocksdb_table_properties_collection_iter_create(props.as_ptr()),
+                _life: PhantomData,
+            }
+        }
+    }
+}
+
+impl<'a> Iterator for TablePropertiesCollectionIter<'a> {
+    type Item = (&'a [u8], &'a TableProperties);
+
+    #[inline]
+    fn next(&mut self) -> Option<(&'a [u8], &'a TableProperties)> {
+        unsafe {
+            let (mut key, mut val) = (r(&[]), ptr::null());
+            if tirocks_sys::crocksdb_table_properties_collection_iter_next(
+                self.ptr, &mut key, &mut val,
+            ) {
+                Some((s(key), TableProperties::from_ptr(val)))
+            } else {
+                None
+            }
+        }
+    }
+}

--- a/tirocks/src/table_properties/user.rs
+++ b/tirocks/src/table_properties/user.rs
@@ -1,0 +1,285 @@
+// Copyright 2022 TiKV Project Authors. Licensed under Apache-2.0.
+
+use std::{ffi::CStr, marker::PhantomData, ops::Index, ptr};
+
+use libc::{c_char, c_void};
+use tirocks_sys::{
+    crocksdb_table_properties_collector_factory_t, crocksdb_table_properties_collector_t,
+    crocksdb_user_collected_properties_iterator_t, r, rocksdb_Slice, rocksdb_Status,
+    rocksdb_UserCollectedProperties, s,
+};
+
+use crate::Status;
+
+pub type SequenceNumber = tirocks_sys::rocksdb_SequenceNumber;
+pub type EntryType = tirocks_sys::rocksdb_EntryType;
+pub type Context = tirocks_sys::rocksdb_TablePropertiesCollectorFactory_Context;
+
+/// Other than basic table properties, each table may also have the user
+/// collected properties.
+/// The value of the user-collected properties are encoded as raw bytes --
+/// users have to interpret these values by themselves.
+#[repr(transparent)]
+pub struct UserCollectedProperties(tirocks_sys::rocksdb_UserCollectedProperties);
+
+impl UserCollectedProperties {
+    #[inline]
+    pub(crate) unsafe fn from_ptr<'a>(
+        ptr: *const tirocks_sys::rocksdb_UserCollectedProperties,
+    ) -> &'a UserCollectedProperties {
+        &*(ptr as *const UserCollectedProperties)
+    }
+
+    #[inline]
+    pub(crate) unsafe fn from_ptr_mut<'a>(
+        ptr: *mut tirocks_sys::rocksdb_UserCollectedProperties,
+    ) -> &'a mut UserCollectedProperties {
+        &mut *(ptr as *mut UserCollectedProperties)
+    }
+
+    #[inline]
+    pub fn get(&self, index: impl AsRef<[u8]>) -> Option<&[u8]> {
+        let bytes = index.as_ref();
+        unsafe {
+            let mut val = r(&[]);
+            let exists = tirocks_sys::crocksdb_user_collected_properties_get(
+                self as *const _ as _,
+                r(bytes),
+                &mut val,
+            );
+            if exists {
+                return Some(s(val));
+            }
+            None
+        }
+    }
+
+    #[inline]
+    pub fn len(&self) -> usize {
+        unsafe { tirocks_sys::crocksdb_user_collected_properties_len(self as *const _ as _) }
+    }
+
+    #[inline]
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    #[inline]
+    pub fn add(&mut self, key: &[u8], val: &[u8]) {
+        unsafe {
+            tirocks_sys::crocksdb_user_collected_properties_add(self as *mut _ as _, r(key), r(val))
+        }
+    }
+}
+
+impl<Q: AsRef<[u8]>> Index<Q> for UserCollectedProperties {
+    type Output = [u8];
+
+    #[inline]
+    fn index(&self, index: Q) -> &[u8] {
+        let key = index.as_ref();
+        self.get(key)
+            .unwrap_or_else(|| panic!("no entry found for key {:?}", key))
+    }
+}
+
+impl<'a> IntoIterator for &'a UserCollectedProperties {
+    type Item = (&'a [u8], &'a [u8]);
+    type IntoIter = UserCollectedPropertiesIter<'a>;
+
+    #[inline]
+    fn into_iter(self) -> Self::IntoIter {
+        UserCollectedPropertiesIter::new(self)
+    }
+}
+
+pub struct UserCollectedPropertiesIter<'a> {
+    ptr: *mut crocksdb_user_collected_properties_iterator_t,
+    _life: PhantomData<&'a UserCollectedProperties>,
+}
+
+impl<'a> Drop for UserCollectedPropertiesIter<'a> {
+    #[inline]
+    fn drop(&mut self) {
+        unsafe {
+            tirocks_sys::crocksdb_user_collected_properties_iter_destroy(self.ptr);
+        }
+    }
+}
+
+impl<'a> UserCollectedPropertiesIter<'a> {
+    #[inline]
+    fn new(props: &'a UserCollectedProperties) -> UserCollectedPropertiesIter<'a> {
+        unsafe {
+            UserCollectedPropertiesIter {
+                ptr: tirocks_sys::crocksdb_user_collected_properties_iter_create(
+                    props as *const _ as _,
+                ),
+                _life: PhantomData,
+            }
+        }
+    }
+}
+
+impl<'a> Iterator for UserCollectedPropertiesIter<'a> {
+    type Item = (&'a [u8], &'a [u8]);
+
+    #[inline]
+    fn next(&mut self) -> Option<(&'a [u8], &'a [u8])> {
+        unsafe {
+            let (mut key, mut val) = (r(&[]), r(&[]));
+            if tirocks_sys::crocksdb_user_collected_properties_iter_next(
+                self.ptr, &mut key, &mut val,
+            ) {
+                Some((s(key), s(val)))
+            } else {
+                None
+            }
+        }
+    }
+}
+
+/// `TablePropertiesCollector` provides the mechanism for users to collect
+/// their own properties that they are interested in. This class is essentially
+/// a collection of callback functions that will be invoked during table
+/// building. It is constructed with TablePropertiesCollectorFactory. The methods
+/// don't need to be thread-safe, as we will create exactly one
+/// TablePropertiesCollector object per table and then call it sequentially
+pub trait TablePropertiesCollector {
+    /// The name of the properties collector can be used for debugging purpose.
+    fn name(&self) -> &CStr;
+
+    /// Will be called when a new key/value pair is inserted into the table.
+    fn add(
+        &mut self,
+        key: &[u8],
+        value: &[u8],
+        entry_type: EntryType,
+        seq: SequenceNumber,
+        file_size: u64,
+    ) -> Status;
+
+    /// Will be called when a table has already been built and is ready for
+    /// writing the properties block.
+    fn finish(&mut self, properties: &mut UserCollectedProperties) -> Status;
+}
+
+extern "C" fn collector_name<T: TablePropertiesCollector>(handle: *mut c_void) -> *const c_char {
+    unsafe {
+        let handle = &mut *(handle as *mut T);
+        handle.name().as_ptr()
+    }
+}
+
+extern "C" fn collector_destruct<T: TablePropertiesCollector>(handle: *mut c_void) {
+    unsafe {
+        drop(Box::from_raw(handle as *mut T));
+    }
+}
+
+extern "C" fn collector_add<T: TablePropertiesCollector>(
+    handle: *mut c_void,
+    key: rocksdb_Slice,
+    value: rocksdb_Slice,
+    entry_type: EntryType,
+    seq: SequenceNumber,
+    file_size: u64,
+    status: *mut rocksdb_Status,
+) {
+    unsafe {
+        let handle = &mut *(handle as *mut T);
+        let s = handle.add(s(key), s(value), entry_type, seq, file_size);
+        ptr::write(status, s.into_raw());
+    }
+}
+
+extern "C" fn collector_finish<T: TablePropertiesCollector>(
+    handle: *mut c_void,
+    props: *mut rocksdb_UserCollectedProperties,
+    status: *mut rocksdb_Status,
+) {
+    unsafe {
+        let handle = &mut *(handle as *mut T);
+        let s = handle.finish(&mut *(props as *mut UserCollectedProperties));
+        ptr::write(status, s.into_raw());
+    }
+}
+
+/// Constructs `TablePropertiesCollector`.
+/// Internals create a new `TablePropertiesCollector` for each new table.
+pub trait TablePropertiesCollectorFactory: Send + Sync {
+    type Collector: TablePropertiesCollector;
+
+    /// The name of the properties collector can be used for debugging purpose.
+    fn name(&self) -> &CStr;
+
+    /// Has to be thread-safe.
+    fn create_table_properties_collector(&self, ctx: Context) -> Self::Collector;
+}
+
+extern "C" fn factory_name<T: TablePropertiesCollectorFactory>(
+    factory: *mut c_void,
+) -> *const c_char {
+    unsafe {
+        let factory = &mut *(factory as *mut T);
+        factory.name().as_ptr()
+    }
+}
+
+extern "C" fn factory_destruct<T: TablePropertiesCollectorFactory>(handle: *mut c_void) {
+    unsafe {
+        Box::from_raw(handle as *mut T);
+    }
+}
+
+extern "C" fn create_table_properties_collector<T: TablePropertiesCollectorFactory>(
+    handle: *mut c_void,
+    ctx: Context,
+) -> *mut crocksdb_table_properties_collector_t {
+    unsafe {
+        let handle = &mut *(handle as *mut T);
+        let collector = handle.create_table_properties_collector(ctx);
+        tirocks_sys::crocksdb_table_properties_collector_create(
+            Box::into_raw(Box::new(collector)) as *mut c_void,
+            Some(collector_name::<T::Collector>),
+            Some(collector_destruct::<T::Collector>),
+            Some(collector_add::<T::Collector>),
+            Some(collector_finish::<T::Collector>),
+        )
+    }
+}
+
+/// A wrapped factory that can be shared by multiple ColumnFamilies and DBs.
+#[derive(Debug)]
+pub struct SysTablePropertiesCollectorFactory {
+    ptr: *mut crocksdb_table_properties_collector_factory_t,
+}
+
+impl SysTablePropertiesCollectorFactory {
+    #[inline]
+    pub fn new<T: TablePropertiesCollectorFactory>(
+        factory: T,
+    ) -> SysTablePropertiesCollectorFactory {
+        let ptr = unsafe {
+            tirocks_sys::crocksdb_table_properties_collector_factory_create(
+                Box::into_raw(Box::new(factory)) as *mut c_void,
+                Some(factory_name::<T>),
+                Some(factory_destruct::<T>),
+                Some(create_table_properties_collector::<T>),
+            )
+        };
+        SysTablePropertiesCollectorFactory { ptr }
+    }
+
+    #[inline]
+    pub(crate) fn get(&self) -> *mut crocksdb_table_properties_collector_factory_t {
+        self.ptr
+    }
+}
+
+impl Drop for SysTablePropertiesCollectorFactory {
+    #[inline]
+    fn drop(&mut self) {
+        unsafe { tirocks_sys::crocksdb_table_properties_collector_factory_destroy(self.ptr) }
+    }
+}


### PR DESCRIPTION
This PR implements all kinds of properties.

The differences between rust-rocksdb are:
- Instead of using an enum to test on runtime, tirocks use API explicitly
- Instead of defining `TablePropertiesCollection` and `TablePropertiesCollectionView`, tirocks use the same struct and check for lifetime at runtime.