### PR TITLE
*: add all types required by cf options

### DIFF
--- a/tirocks/src/compaction_filter.rs
+++ b/tirocks/src/compaction_filter.rs
@@ -1,0 +1,322 @@
+// Copyright 2022 TiKV Project Authors. Licensed under Apache-2.0.
+
+use std::{ffi::CStr, ptr, slice};
+
+use libc::{c_char, c_void};
+use tirocks_sys::{
+    crocksdb_compactionfilterfactory_t, r, rocksdb_CompactionFilter,
+    rocksdb_CompactionFilter_Context, rocksdb_CompactionFilter_Decision, rocksdb_Slice, s,
+};
+
+use crate::{
+    properties::{table::builtin::TableProperties, table::user::SequenceNumber},
+    CloneFactory, DefaultFactory,
+};
+
+pub type ValueType = tirocks_sys::rocksdb_CompactionFilter_ValueType;
+pub type TableFileCreationReason = tirocks_sys::rocksdb_TableFileCreationReason;
+
+/// Possible return values for filter.
+pub enum Decision<'a> {
+    /// Keep the key-value pair.
+    Keep,
+    /// Remove the key-value pair or merge operand.
+    Remove,
+    /// Keep the key and change the value/operand.
+    ChangeValue(&'a [u8]),
+    /// Remove this key-value pair, and also remove
+    /// all key-value pairs with key in [key, *skip_until). This range
+    /// of keys will be skipped without reading, potentially saving some
+    /// IO operations compared to removing the keys one by one.
+    ///
+    /// *skip_until <= key is treated the same as Decision::kKeep
+    /// (since the range [key, *skip_until) is empty).
+    ///
+    /// Caveats:
+    ///   - The keys are skipped even if there are snapshots containing them,
+    ///     i.e. values removed by kRemoveAndSkipUntil can disappear from a
+    ///     snapshot - beware if you're using TransactionDB or
+    ///     DB::GetSnapshot().
+    ///   - If value for a key was overwritten or merged into (multiple Put()s
+    ///     or Merge()s), and `CompactionFilter` skips this key with
+    ///     kRemoveAndSkipUntil, it's possible that it will remove only
+    ///     the new value, exposing the old value that was supposed to be
+    ///     overwritten.
+    ///   - Doesn't work with PlainTableFactory in prefix mode.
+    ///   - If you use kRemoveAndSkipUntil for table files created by
+    ///     compaction, consider also reducing compaction_readahead_size
+    ///     option.
+    RemoveAndSKipUntil(&'a [u8]),
+}
+
+/// CompactionFilter allows an application to modify/delete a key-value during
+/// table file creation.
+pub trait CompactionFilter: Send {
+    /// Returns a name that identifies this `CompactionFilter`.
+    /// The name will be printed to LOG file on start up for diagnosis.
+    fn name(&mut self) -> &CStr;
+
+    /// Allows changing value and skipping ranges of keys.
+    /// The default implementation uses Filter() and FilterMergeOperand().
+    /// If you're overriding this method, no need to override the other two.
+    /// `value_type` indicates whether this key-value corresponds to a normal
+    /// value (e.g. written with Put())  or a merge operand (written with Merge()).
+    ///
+    /// Note: If you are using a TransactionDB, it is not recommended to filter
+    /// out or modify merge operands (ValueType::kMergeOperand).
+    /// If a merge operation is filtered out, TransactionDB may not realize there
+    /// is a write conflict and may allow a Transaction to Commit that should have
+    /// failed. Instead, it is better to implement any Merge filtering inside the
+    /// MergeOperator.
+    ///
+    /// Note: for kTypeBlobIndex, `key` is internal key instead of user key.
+    fn filter(
+        &mut self,
+        level: i32,
+        key: &[u8],
+        seqno: SequenceNumber,
+        value_type: ValueType,
+        existing_value: &[u8],
+    ) -> Decision;
+}
+
+extern "C" fn name<F: CompactionFilter>(c: *mut c_void) -> *const c_char {
+    unsafe {
+        let c = &mut *(c as *mut F);
+        c.name().as_ptr()
+    }
+}
+
+extern "C" fn destructor<F: CompactionFilter>(c: *mut c_void) {
+    unsafe {
+        drop(Box::from_raw(c as *mut F));
+    }
+}
+
+extern "C" fn filter<F: CompactionFilter>(
+    c: *mut c_void,
+    level: i32,
+    key: rocksdb_Slice,
+    seqno: SequenceNumber,
+    value_type: ValueType,
+    existing_value: rocksdb_Slice,
+    new_value: *mut rocksdb_Slice,
+    skip_until: *mut rocksdb_Slice,
+) -> rocksdb_CompactionFilter_Decision {
+    unsafe {
+        // Hack: Tenichally, the lifetime of ChangeValue and RemoveAndSkipUntil only lives
+        // in this function scope. However, technically, it's impossible for a function to
+        // return a value that only valid during its caller. Instead, it will have to store
+        // the value inside `c` or in some global variables, which means it should be valid
+        // at least before the next call or `c` is destroyed. Both of them are guaranteed not
+        // to happen when accessing the value.
+        let c = &mut *(c as *mut F);
+        match c.filter(level, s(key), seqno, value_type, s(existing_value)) {
+            Decision::Keep => rocksdb_CompactionFilter_Decision::kKeep,
+            Decision::Remove => rocksdb_CompactionFilter_Decision::kRemove,
+            Decision::ChangeValue(v) => {
+                *new_value = r(v);
+                rocksdb_CompactionFilter_Decision::kChangeValue
+            }
+            Decision::RemoveAndSKipUntil(v) => {
+                *skip_until = r(v);
+                rocksdb_CompactionFilter_Decision::kRemoveAndSkipUntil
+            }
+        }
+    }
+}
+
+/// Context information for a table file creation.
+#[repr(transparent)]
+pub struct Context(rocksdb_CompactionFilter_Context);
+
+impl Context {
+    #[inline]
+    fn as_ptr(&self) -> *const rocksdb_CompactionFilter_Context {
+        self as *const _ as _
+    }
+
+    /// Whether this table file is created as part of a compaction including all
+    /// table files.
+    #[inline]
+    pub fn is_full_compaction(&self) -> bool {
+        unsafe { tirocks_sys::crocksdb_compactionfiltercontext_is_full_compaction(self.as_ptr()) }
+    }
+
+    /// Whether this table file is created as part of a compaction requested by
+    /// the client.
+    #[inline]
+    pub fn is_manual_compaction(&self) -> bool {
+        unsafe { tirocks_sys::crocksdb_compactionfiltercontext_is_manual_compaction(self.as_ptr()) }
+    }
+
+    /// Whether output files are in bottommost level or not.
+    #[inline]
+    pub fn is_bottommost_level(&self) -> bool {
+        unsafe { tirocks_sys::crocksdb_compactionfiltercontext_is_bottommost_level(self.as_ptr()) }
+    }
+
+    /// File numbers of all involved SST files.
+    #[inline]
+    pub fn file_numbers(&self) -> &[u64] {
+        let (mut buffer, mut len): (*const u64, usize) = (ptr::null_mut(), 0);
+        unsafe {
+            tirocks_sys::crocksdb_compactionfiltercontext_file_numbers(
+                self.as_ptr(),
+                &mut buffer,
+                &mut len,
+            );
+            slice::from_raw_parts(buffer, len)
+        }
+    }
+
+    /// Properties of involved SST files.
+    #[inline]
+    pub fn table_properties(&self, offset: usize) -> &TableProperties {
+        unsafe {
+            let raw = tirocks_sys::crocksdb_compactionfiltercontext_table_properties(
+                self.as_ptr(),
+                offset,
+            );
+            TableProperties::from_ptr(raw)
+        }
+    }
+
+    /// The range of the compaction.
+    #[inline]
+    pub fn start_key(&self) -> &[u8] {
+        unsafe {
+            let mut buf = r(&[]);
+            tirocks_sys::crocksdb_compactionfiltercontext_start_key(self.as_ptr(), &mut buf);
+            s(buf)
+        }
+    }
+
+    /// The range of the compaction.
+    #[inline]
+    pub fn end_key(&self) -> &[u8] {
+        unsafe {
+            let mut buf = r(&[]);
+            tirocks_sys::crocksdb_compactionfiltercontext_end_key(self.as_ptr(), &mut buf);
+            s(buf)
+        }
+    }
+}
+
+pub trait CompactionFilterFactory: Send + Sync {
+    type Filter: CompactionFilter;
+
+    /// Returns whether a thread creating table files for the specified `reason`
+    /// should invoke `CreateCompactionFilter()` and pass KVs through the returned
+    /// filter.
+    fn should_filter_table_file_creation(&self, reason: TableFileCreationReason) -> bool {
+        reason == TableFileCreationReason::kCompaction
+    }
+
+    fn create_compaction_filter(&self, context: &Context) -> Self::Filter;
+
+    /// Returns a name that identifies this `CompactionFilter` factory.
+    fn name(&self) -> &CStr;
+}
+
+impl<F: Default + CompactionFilter> CompactionFilterFactory for DefaultFactory<F> {
+    type Filter = F;
+
+    #[inline]
+    fn create_compaction_filter(&self, _: &Context) -> Self::Filter {
+        F::default()
+    }
+
+    #[inline]
+    fn name(&self) -> &CStr {
+        self.c_name()
+    }
+}
+
+impl<F: Clone + CompactionFilter + Send + Sync> CompactionFilterFactory for CloneFactory<F> {
+    type Filter = F;
+
+    #[inline]
+    fn create_compaction_filter(&self, _: &Context) -> Self::Filter {
+        self.clone()
+    }
+
+    #[inline]
+    fn name(&self) -> &CStr {
+        self.c_name()
+    }
+}
+
+extern "C" fn factory_name<T: CompactionFilterFactory>(factory: *mut c_void) -> *const c_char {
+    unsafe {
+        let factory = &mut *(factory as *mut T);
+        factory.name().as_ptr()
+    }
+}
+
+extern "C" fn factory_destruct<T: CompactionFilterFactory>(handle: *mut c_void) {
+    unsafe {
+        Box::from_raw(handle as *mut T);
+    }
+}
+
+extern "C" fn create_compaction_filter<T: CompactionFilterFactory>(
+    handle: *mut c_void,
+    context: *const rocksdb_CompactionFilter_Context,
+) -> *mut rocksdb_CompactionFilter {
+    unsafe {
+        let handle = &*(handle as *mut T);
+        let context = &*(context as *const Context);
+        let f = handle.create_compaction_filter(context);
+        tirocks_sys::crocksdb_compactionfilter_create(
+            Box::into_raw(Box::new(f)) as *mut c_void,
+            Some(destructor::<T::Filter>),
+            Some(filter::<T::Filter>),
+            Some(name::<T::Filter>),
+        )
+    }
+}
+
+extern "C" fn should_filter_table_file_creation<T: CompactionFilterFactory>(
+    handle: *mut c_void,
+    reason: TableFileCreationReason,
+) -> bool {
+    unsafe {
+        let handle = &*(handle as *mut T);
+        handle.should_filter_table_file_creation(reason)
+    }
+}
+
+/// A wrapped factory that can be shared by multiple ColumnFamilies and DBs.
+#[derive(Debug)]
+pub struct SysCompactionFilterFactory {
+    ptr: *mut crocksdb_compactionfilterfactory_t,
+}
+
+impl SysCompactionFilterFactory {
+    #[inline]
+    pub fn new<T: CompactionFilterFactory>(factory: T) -> SysCompactionFilterFactory {
+        let ptr = unsafe {
+            tirocks_sys::crocksdb_compactionfilterfactory_create(
+                Box::into_raw(Box::new(factory)) as *mut c_void,
+                Some(factory_destruct::<T>),
+                Some(create_compaction_filter::<T>),
+                Some(should_filter_table_file_creation::<T>),
+                Some(factory_name::<T>),
+            )
+        };
+        SysCompactionFilterFactory { ptr }
+    }
+
+    #[inline]
+    pub(crate) fn get_ptr(&self) -> *mut crocksdb_compactionfilterfactory_t {
+        self.ptr
+    }
+}
+
+impl Drop for SysCompactionFilterFactory {
+    #[inline]
+    fn drop(&mut self) {
+        unsafe { tirocks_sys::crocksdb_compactionfilterfactory_destroy(self.ptr) }
+    }
+}

--- a/tirocks/src/env.rs
+++ b/tirocks/src/env.rs
@@ -9,8 +9,7 @@ use std::path::Path;
 use self::inspected::SysFileSystemInspector;
 #[cfg(feature = "encryption")]
 use crate::encryption::{KeyManager, SysKeyManager};
-use crate::error::ffi_call;
-use crate::util::PathToSlice;
+use crate::util::{PathToSlice, ffi_call};
 use crate::{Code, Result, Status};
 use libc::c_char;
 use tirocks_sys::rocksdb_EnvOptions;

--- a/tirocks/src/env.rs
+++ b/tirocks/src/env.rs
@@ -9,7 +9,7 @@ use std::path::Path;
 use self::inspected::SysFileSystemInspector;
 #[cfg(feature = "encryption")]
 use crate::encryption::{KeyManager, SysKeyManager};
-use crate::util::{PathToSlice, ffi_call};
+use crate::util::{ffi_call, PathToSlice};
 use crate::{Code, Result, Status};
 use libc::c_char;
 use tirocks_sys::rocksdb_EnvOptions;

--- a/tirocks/src/env/inspected.rs
+++ b/tirocks/src/env/inspected.rs
@@ -97,11 +97,11 @@ impl Drop for SysFileSystemInspector {
 impl FileSystemInspector for SysFileSystemInspector {
     #[inline]
     fn read(&self, len: usize) -> Result<usize> {
-        unsafe { crate::error::ffi_call!(crocksdb_file_system_inspector_read(self.ptr, len)) }
+        unsafe { crate::util::ffi_call!(crocksdb_file_system_inspector_read(self.ptr, len)) }
     }
 
     #[inline]
     fn write(&self, len: usize) -> Result<usize> {
-        unsafe { crate::error::ffi_call!(crocksdb_file_system_inspector_write(self.ptr, len)) }
+        unsafe { crate::util::ffi_call!(crocksdb_file_system_inspector_write(self.ptr, len)) }
     }
 }

--- a/tirocks/src/env/sequential_file.rs
+++ b/tirocks/src/env/sequential_file.rs
@@ -2,7 +2,7 @@
 
 use std::io::{self, Read};
 
-use crate::{error::ffi_call, Result};
+use crate::{Result, util::ffi_call};
 use tirocks_sys::crocksdb_sequential_file_t;
 
 /// A file abstraction for reading sequentially through a file.

--- a/tirocks/src/env/sequential_file.rs
+++ b/tirocks/src/env/sequential_file.rs
@@ -2,7 +2,7 @@
 
 use std::io::{self, Read};
 
-use crate::{Result, util::ffi_call};
+use crate::{util::ffi_call, Result};
 use tirocks_sys::crocksdb_sequential_file_t;
 
 /// A file abstraction for reading sequentially through a file.

--- a/tirocks/src/error.rs
+++ b/tirocks/src/error.rs
@@ -7,6 +7,7 @@ use std::str::Utf8Error;
 use tirocks_sys::rocksdb_Status;
 
 /// A safe wrapper around rocksdb::Status.
+#[derive(PartialEq)]
 #[repr(transparent)]
 pub struct Status(rocksdb_Status);
 
@@ -180,44 +181,6 @@ impl Debug for Status {
 }
 
 pub type Result<T> = std::result::Result<T, Status>;
-
-/// A helper micros for handling FFI calls that need error handling.
-///
-/// It's simply translate the call
-/// ```ignored
-/// ffi_call!(func(...))
-/// ```
-/// to
-/// ```ignored
-/// let res = tirocks_sys::func(..., &mut status);
-/// if status.ok() {
-///     Ok(res)
-/// } else {
-///     Err(status)
-/// }
-/// ```
-macro_rules! ffi_call {
-    ($func:ident($($arg:expr),+)) => ({
-        let mut status = $crate::Status::default();
-        let res = tirocks_sys::$func($($arg),+, status.as_mut_ptr());
-        if status.ok() {
-            Ok(res)
-        } else {
-            Err(status)
-        }
-    });
-    ($func:ident()) => ({
-        let mut status = $crate::Status::default();
-        let res = tirocks_sys::$func(status.as_mut_ptr());
-        if status.ok() {
-            Ok(res)
-        } else {
-            Err(status)
-        }
-    })
-}
-
-pub(crate) use ffi_call;
 
 #[cfg(test)]
 mod tests {

--- a/tirocks/src/lib.rs
+++ b/tirocks/src/lib.rs
@@ -5,15 +5,20 @@
 #![allow(unused)]
 
 pub mod cache;
+pub mod compaction_filter;
 pub mod comparator;
 #[cfg(feature = "encryption")]
 pub mod encryption;
 pub mod env;
 mod error;
 pub mod listener;
+pub mod mem_table;
+pub mod merge_operator;
 pub mod option;
 pub mod properties;
 pub mod rate_limiter;
+pub mod slice_transform;
+pub mod sst_partitioner;
 pub mod statistics;
 // TODO: remove this when options are all implemented.
 #[allow(unused)]
@@ -22,7 +27,9 @@ pub mod table_filter;
 mod util;
 
 pub use error::{Code, Result, Severity, Status, SubCode};
+pub use option::{CfOptions, DbOptions, Options};
 pub use statistics::Statistics;
+pub use util::{CloneFactory, DefaultFactory};
 use tirocks_sys::rocksdb_DB;
 
 // TODO: define later.

--- a/tirocks/src/lib.rs
+++ b/tirocks/src/lib.rs
@@ -27,10 +27,10 @@ pub mod table_filter;
 mod util;
 
 pub use error::{Code, Result, Severity, Status, SubCode};
-pub use option::{CfOptions, DbOptions, Options};
+pub use option::DbOptions;
 pub use statistics::Statistics;
-pub use util::{CloneFactory, DefaultFactory};
 use tirocks_sys::rocksdb_DB;
+pub use util::{CloneFactory, DefaultFactory};
 
 // TODO: define later.
 pub struct RawDb;

--- a/tirocks/src/mem_table.rs
+++ b/tirocks/src/mem_table.rs
@@ -1,0 +1,71 @@
+// Copyright 2022 TiKV Project Authors. Licensed under Apache-2.0.
+
+use std::str::{self, Utf8Error};
+
+use tirocks_sys::{crocksdb_memtablerepfactory_t, r, s};
+
+#[derive(Debug)]
+pub struct SysMemTableRepFactory {
+    ptr: *mut crocksdb_memtablerepfactory_t,
+}
+
+impl SysMemTableRepFactory {
+    #[inline]
+    pub fn with_hash_skip_list(
+        bucket_count: usize,
+        skip_list_height: i32,
+        skip_list_branching_factor: i32,
+    ) -> Self {
+        let ptr = unsafe {
+            tirocks_sys::crocksdb_memtablerepfactory_create_hash_skip_list(
+                bucket_count,
+                skip_list_height,
+                skip_list_branching_factor,
+            )
+        };
+        Self { ptr }
+    }
+
+    #[inline]
+    pub fn with_hash_link_list(bucket_count: usize) -> Self {
+        let ptr =
+            unsafe { tirocks_sys::crocksdb_memtablerepfactory_create_hash_link_list(bucket_count) };
+        Self { ptr }
+    }
+
+    #[inline]
+    pub fn with_doubly_skip_list(lookahead: usize) -> Self {
+        let ptr =
+            unsafe { tirocks_sys::crocksdb_memtablerepfactory_create_doubly_skip_list(lookahead) };
+        Self { ptr }
+    }
+
+    #[inline]
+    pub fn with_vector(reserved_bytes: u64) -> Self {
+        let ptr = unsafe { tirocks_sys::crocksdb_memtablerepfactory_create_vector(reserved_bytes) };
+        Self { ptr }
+    }
+
+    #[inline]
+    pub fn name(&self) -> std::result::Result<&str, Utf8Error> {
+        unsafe {
+            let mut name = r(&[]);
+            tirocks_sys::crocksdb_memtablerepfactory_name(self.ptr, &mut name);
+            str::from_utf8(s(name))
+        }
+    }
+
+    #[inline]
+    pub(crate) fn get_ptr(&self) -> *mut crocksdb_memtablerepfactory_t {
+        self.ptr
+    }
+}
+
+impl Drop for SysMemTableRepFactory {
+    #[inline]
+    fn drop(&mut self) {
+        unsafe {
+            tirocks_sys::crocksdb_memtablerepfactory_destroy(self.ptr);
+        }
+    }
+}

--- a/tirocks/src/merge_operator.rs
+++ b/tirocks/src/merge_operator.rs
@@ -1,0 +1,436 @@
+// Copyright 2022 TiKV Project Authors. Licensed under Apache-2.0.
+
+use std::{borrow::Cow, ffi::CStr, os::raw::c_char, ptr, slice};
+
+use libc::c_void;
+use tirocks_sys::{
+    crocksdb_mergeoperator_t, r, rocksdb_MergeOperator_MergeOperationInput,
+    rocksdb_MergeOperator_MergeOperationOutput, rocksdb_MergeOperator_MergeValueType,
+    rocksdb_Slice, s,
+};
+
+use crate::util;
+
+pub type MergeValueType = rocksdb_MergeOperator_MergeValueType;
+
+#[repr(transparent)]
+pub struct MergeOperationInput(rocksdb_MergeOperator_MergeOperationInput);
+
+impl MergeOperationInput {
+    fn as_ptr(&self) -> *const rocksdb_MergeOperator_MergeOperationInput {
+        self as *const _ as _
+    }
+
+    /// The key associated with the merge operation.
+    #[inline]
+    pub fn key(&self) -> &[u8] {
+        unsafe {
+            let mut buf = r(&[]);
+            tirocks_sys::crocksdb_mergeoperationinput_key(self.as_ptr(), &mut buf);
+            s(buf)
+        }
+    }
+
+    /// The value type associated with the existing_value, ignore this field
+    /// if existing_value is None.
+    #[inline]
+    pub fn value_type(&self) -> MergeValueType {
+        unsafe { tirocks_sys::crocksdb_mergeoperationinput_value_type(self.as_ptr()) }
+    }
+
+    /// The existing value of the current key, None means that the value doesn't exist.
+    #[inline]
+    pub fn existing_value(&self) -> Option<&[u8]> {
+        unsafe {
+            let mut v = ptr::null();
+            tirocks_sys::crocksdb_mergeoperationinput_existing_value(self.as_ptr(), &mut v);
+            if !v.is_null() {
+                Some(s(*v))
+            } else {
+                None
+            }
+        }
+    }
+
+    /// A list of operands to apply.
+    #[inline]
+    pub fn operand_list(&self) -> Cow<[&[u8]]> {
+        unsafe {
+            let mut p = ptr::null();
+            let mut size = 0;
+            tirocks_sys::crocksdb_mergeoperationinput_operand_list(
+                self.as_ptr(),
+                &mut p,
+                &mut size,
+            );
+            let arr = slice::from_raw_parts(p, size);
+            util::rocks_slice_to_array(arr)
+        }
+    }
+}
+
+#[repr(transparent)]
+pub struct MergeOperationOutput(rocksdb_MergeOperator_MergeOperationOutput);
+
+impl MergeOperationOutput {
+    fn as_mut_ptr(&mut self) -> *mut rocksdb_MergeOperator_MergeOperationOutput {
+        self as *mut _ as _
+    }
+
+    /// Client is responsible for filling the merge result here.
+    #[inline]
+    pub fn set_new_value(&mut self, value: &[u8]) -> &mut Self {
+        unsafe {
+            tirocks_sys::crocksdb_mergeoperationoutput_set_new_value(self.as_mut_ptr(), r(value));
+        }
+        self
+    }
+
+    #[inline]
+    pub fn append_new_value(&mut self, value: &[u8]) -> &mut Self {
+        unsafe {
+            tirocks_sys::crocksdb_mergeoperationoutput_append_new_value(
+                self.as_mut_ptr(),
+                r(value),
+            );
+        }
+        self
+    }
+
+    /// If the merge result is one of the existing operands client can set this field to
+    /// the operand instead of using new_value.
+    #[inline]
+    pub fn set_existing_operand(&mut self, input: &MergeOperationInput, pos: usize) -> &mut Self {
+        unsafe {
+            tirocks_sys::crocksdb_mergeoperationoutput_set_existing_operand(
+                self.as_mut_ptr(),
+                input.as_ptr(),
+                pos,
+            );
+        }
+        self
+    }
+
+    /// If the merge result is existing_value, client can set this field to existing_value instead
+    /// of using new_value.
+    #[inline]
+    pub fn set_existing_operand_to_value(&mut self, input: &MergeOperationInput) -> &mut Self {
+        unsafe {
+            tirocks_sys::crocksdb_mergeoperationoutput_set_existing_operand_to_value(
+                self.as_mut_ptr(),
+                input.as_ptr(),
+            )
+        }
+        self
+    }
+
+    /// new value type of merge result.
+    #[inline]
+    pub fn set_new_type(&mut self, new_type: MergeValueType) -> &mut Self {
+        unsafe {
+            tirocks_sys::crocksdb_mergeoperationoutput_set_new_type(self.as_mut_ptr(), new_type);
+        }
+        self
+    }
+}
+
+type AppendCb = Option<unsafe extern "C" fn(*mut c_void, rocksdb_Slice)>;
+
+unsafe extern "C" fn append_to_output(ctx: *mut c_void, v: rocksdb_Slice) {
+    let c = &mut *(ctx as *mut MergeOperationOutput);
+    c.append_new_value(s(v));
+}
+
+pub struct NewValue {
+    ctx: *mut c_void,
+    func: AppendCb,
+}
+
+impl NewValue {
+    pub fn append(&mut self, v: &[u8]) {
+        unsafe { self.func.unwrap()(self.ctx, r(v)) }
+    }
+
+    pub unsafe fn with_output(output: &mut MergeOperationOutput) -> NewValue {
+        NewValue {
+            ctx: output as *mut _ as _,
+            func: Some(append_to_output),
+        }
+    }
+}
+
+/// The Merge Operator
+///
+/// Essentially, a MergeOperator specifies the SEMANTICS of a merge, which only
+/// client knows. It could be numeric addition, list append, string
+/// concatenation, edit data structure, ... , anything.
+/// The library, on the other hand, is concerned with the exercise of this
+/// interface, at the right time (during get, iteration, compaction...)
+///
+/// To use merge, the client needs to provide an object implementing one of
+/// the following interfaces:
+///  a) AssociativeMergeOperator - for most simple semantics (always take
+///    two values, and merge them into one value, which is then put back
+///    into rocksdb); numeric addition and string concatenation are examples;
+///
+///  b) MergeOperator - the generic class for all the more abstract / complex
+///    operations; one method (FullMergeV2) to merge a Put/Delete value with a
+///    merge operand; and another method (PartialMerge) that merges multiple
+///    operands together. this is especially useful if your key values have
+///    complex structures but you would still like to support client-specific
+///    incremental updates.
+///
+/// AssociativeMergeOperator is simpler to implement. MergeOperator is simply
+/// more powerful.
+///
+/// Refer to rocksdb-merge wiki for more details and example implementations.
+pub trait MergeOperator: Send + Sync {
+    /// The name of the MergeOperator. Used to check for MergeOperator
+    /// mismatches (i.e., a DB created with one MergeOperator is
+    /// accessed using a different MergeOperator)
+    fn name(&self) -> &CStr;
+
+    /// This function applies a stack of merge operands in chrionological order
+    /// on top of an existing value. There are two ways in which this method is
+    /// being used:
+    /// a) During Get() operation, it used to calculate the final value of a key
+    /// b) During compaction, in order to collapse some operands with the based
+    ///    value.
+    ///
+    /// Note: The name of the method is somewhat misleading, as both in the cases
+    /// of Get() or compaction it may be called on a subset of operands:
+    /// ```text
+    /// K:    0    +1    +2    +7    +4     +5      2     +1     +2
+    ///                              ^
+    ///                              |
+    ///                          snapshot
+    /// ```
+    ///
+    /// In the example above, Get(K) operation will call FullMerge with a base
+    /// value of 2 and operands [+1, +2]. Compaction process might decide to
+    /// collapse the beginning of the history up to the snapshot by performing
+    /// full Merge with base value of 0 and operands [+1, +2, +7, +3].
+    fn full_merge(&self, input: &MergeOperationInput, output: &mut MergeOperationOutput) -> bool;
+
+    /// This function performs merge(left_op, right_op)
+    /// when both the operands are themselves merge operation types
+    /// that you would have passed to a DB::Merge() call in the same order
+    /// (i.e.: DB::Merge(key,left_op), followed by DB::Merge(key,right_op)).
+    ///
+    /// PartialMerge should combine them into a single merge operation that is
+    /// saved into *new_value, and then it should return true.
+    /// *new_value should be constructed such that a call to
+    /// DB::Merge(key, *new_value) would yield the same result as a call
+    /// to DB::Merge(key, left_op) followed by DB::Merge(key, right_op).
+    ///
+    /// The string that new_value is pointing to will be empty.
+    ///
+    /// The default implementation of PartialMergeMulti will use this function
+    /// as a helper, for backward compatibility.  Any successor class of
+    /// MergeOperator should either implement PartialMerge or PartialMergeMulti,
+    /// although implementing PartialMergeMulti is suggested as it is in general
+    /// more effective to merge multiple operands at a time instead of two
+    /// operands at a time.
+    ///
+    /// If it is impossible or infeasible to combine the two operations,
+    /// leave new_value unchanged and return false. The library will
+    /// internally keep track of the operations, and apply them in the
+    /// correct order once a base-value (a Put/Delete/End-of-Database) is seen.
+    fn partial_merge(&self, key: &[u8], lhs: &[u8], rhs: &[u8], new_value: &mut NewValue) -> bool;
+
+    /// This function performs merge when all the operands are themselves merge
+    /// operation types that you would have passed to a DB::Merge() call in the
+    /// same order (front() first)
+    /// (i.e. DB::Merge(key, operand_list[0]), followed by
+    ///  DB::Merge(key, operand_list[1]), ...)
+    ///
+    /// PartialMergeMulti should combine them into a single merge operation that is
+    /// saved into *new_value, and then it should return true.  *new_value should
+    /// be constructed such that a call to DB::Merge(key, *new_value) would yield
+    /// the same result as subquential individual calls to DB::Merge(key, operand)
+    /// for each operand in operand_list from front() to back().
+    ///
+    /// The string that new_value is pointing to will be empty.
+    ///
+    /// The PartialMergeMulti function will be called when there are at least two
+    /// operands.
+    ///
+    /// In the default implementation, PartialMergeMulti will invoke PartialMerge
+    /// multiple times, where each time it only merges two operands.  Developers
+    /// should either implement PartialMergeMulti, or implement PartialMerge which
+    /// is served as the helper function of the default PartialMergeMulti.
+    fn partial_merge_multi(&self, key: &[u8], operands: &[&[u8]], new_value: &mut NewValue)
+        -> bool;
+
+    /// Determines whether the PartialMerge can be called with just a single
+    /// merge operand.
+    /// Override and return true for allowing a single operand. PartialMerge
+    /// and PartialMergeMulti should be overridden and implemented
+    /// correctly to properly handle a single operand.
+    fn allow_single_operand(&self) -> bool;
+
+    /// Allows to control when to invoke a full merge during Get.
+    /// This could be used to limit the number of merge operands that are looked at
+    /// during a point lookup, thereby helping in limiting the number of levels to
+    /// read from.
+    /// Doesn't help with iterators.
+    ///
+    /// Note: the merge operands are passed to this function in the reversed order
+    /// relative to how they were merged (passed to FullMerge or FullMergeV2)
+    /// for performance reasons, see also:
+    /// https://github.com/facebook/rocksdb/issues/3865
+    fn should_merge(&self, operands: &[&[u8]]) -> bool;
+}
+
+unsafe extern "C" fn full_merge<T: MergeOperator>(
+    ctx: *mut c_void,
+    input: *const rocksdb_MergeOperator_MergeOperationInput,
+    output: *mut rocksdb_MergeOperator_MergeOperationOutput,
+) -> bool {
+    let c = &*(ctx as *mut T);
+    c.full_merge(
+        &*(input as *const MergeOperationInput),
+        &mut *(output as *mut MergeOperationOutput),
+    )
+}
+
+unsafe extern "C" fn partial_merge<T: MergeOperator>(
+    ctx: *mut c_void,
+    key: rocksdb_Slice,
+    lhs: rocksdb_Slice,
+    rhs: rocksdb_Slice,
+    append_ctx: *mut c_void,
+    append_cb: AppendCb,
+) -> bool {
+    let c = &*(ctx as *mut T);
+    c.partial_merge(
+        s(key),
+        s(lhs),
+        s(rhs),
+        &mut NewValue {
+            ctx: append_ctx,
+            func: append_cb,
+        },
+    )
+}
+
+unsafe extern "C" fn partial_merge_mult<T: MergeOperator>(
+    ctx: *mut c_void,
+    key: rocksdb_Slice,
+    ops: *const rocksdb_Slice,
+    count: usize,
+    append_ctx: *mut c_void,
+    append_cb: AppendCb,
+) -> bool {
+    let c = &*(ctx as *mut T);
+    let ops = slice::from_raw_parts(ops, count);
+    let mut new_v = NewValue {
+        ctx: append_ctx,
+        func: append_cb,
+    };
+    let r_ops = util::rocks_slice_to_array(ops);
+    c.partial_merge_multi(s(key), &r_ops, &mut new_v)
+}
+
+unsafe extern "C" fn name<T: MergeOperator>(ctx: *mut c_void) -> *const c_char {
+    let c = &*(ctx as *mut T);
+    c.name().as_ptr()
+}
+
+unsafe extern "C" fn allow_single_operand<T: MergeOperator>(ctx: *mut c_void) -> bool {
+    let c = &*(ctx as *mut T);
+    c.allow_single_operand()
+}
+
+unsafe extern "C" fn should_merge<T: MergeOperator>(
+    ctx: *mut c_void,
+    ops: *const rocksdb_Slice,
+    count: usize,
+) -> bool {
+    let c = &*(ctx as *mut T);
+    let ops = slice::from_raw_parts(ops, count);
+    let r_ops = util::rocks_slice_to_array(ops);
+    c.should_merge(&r_ops)
+}
+
+unsafe extern "C" fn destroy<T: MergeOperator>(ctx: *mut c_void) {
+    drop(Box::from_raw(ctx as *mut T));
+}
+
+impl<F> MergeOperator for F
+where
+    F: Fn(&[u8], Option<&[u8]>, &[&[u8]], &mut NewValue) -> bool + Send + Sync,
+{
+    fn name(&self) -> &CStr {
+        unsafe { CStr::from_bytes_with_nul_unchecked(b"anoy merge operator\0") }
+    }
+
+    fn full_merge(&self, input: &MergeOperationInput, output: &mut MergeOperationOutput) -> bool {
+        unsafe {
+            let mut cb = NewValue::with_output(output);
+            (*self)(
+                input.key(),
+                input.existing_value(),
+                &input.operand_list(),
+                &mut cb,
+            )
+        }
+    }
+
+    fn partial_merge(&self, key: &[u8], lhs: &[u8], rhs: &[u8], new_value: &mut NewValue) -> bool {
+        (*self)(key, None, &[lhs, rhs], new_value)
+    }
+
+    fn partial_merge_multi(
+        &self,
+        key: &[u8],
+        operand_list: &[&[u8]],
+        new_value: &mut NewValue,
+    ) -> bool {
+        (*self)(key, None, operand_list, new_value)
+    }
+
+    fn allow_single_operand(&self) -> bool {
+        false
+    }
+
+    fn should_merge(&self, _: &[&[u8]]) -> bool {
+        false
+    }
+}
+
+#[derive(Debug)]
+pub struct SysMergeOperator {
+    ptr: *mut crocksdb_mergeoperator_t,
+}
+
+impl Drop for SysMergeOperator {
+    #[inline]
+    fn drop(&mut self) {
+        unsafe { tirocks_sys::crocksdb_mergeoperator_destroy(self.ptr) }
+    }
+}
+
+impl SysMergeOperator {
+    #[inline]
+    pub fn new<T: MergeOperator>(t: T) -> Self {
+        unsafe {
+            let ctx = Box::into_raw(Box::new(t));
+            let ptr = tirocks_sys::crocksdb_mergeoperator_create(
+                ctx as *mut c_void,
+                Some(destroy::<T>),
+                Some(full_merge::<T>),
+                Some(partial_merge::<T>),
+                Some(partial_merge_mult::<T>),
+                Some(name::<T>),
+                Some(allow_single_operand::<T>),
+                Some(should_merge::<T>),
+            );
+            Self { ptr }
+        }
+    }
+
+    pub(crate) fn get_ptr(&self) -> *mut crocksdb_mergeoperator_t {
+        self.ptr
+    }
+}

--- a/tirocks/src/slice_transform.rs
+++ b/tirocks/src/slice_transform.rs
@@ -1,0 +1,160 @@
+// Copyright 2022 TiKV Project Authors. Licensed under Apache-2.0.
+
+use std::ffi::CStr;
+
+use libc::{c_char, c_void};
+use tirocks_sys::{crocksdb_slicetransform_t, r, rocksdb_Slice, s};
+
+/// A SliceTransform is a generic pluggable way of transforming one string
+/// to another. Its primary use-case is in configuring rocksdb
+/// to store prefix blooms by setting prefix_extractor in
+/// ColumnFamilyOptions.
+pub trait SliceTransform: Send + Sync {
+    /// Return the name of this transformation.
+    fn name(&self) -> &CStr;
+
+    /// Extract a prefix from a specified key. This method is called when
+    /// a key is inserted into the db, and the returned slice is used to
+    /// create a bloom filter.
+    fn transform<'a>(&self, key: &'a [u8]) -> &'a [u8];
+
+    /// Determine whether the specified key is compatible with the logic
+    /// specified in the Transform method. This method is invoked for every
+    /// key that is inserted into the db. If this method returns true,
+    /// then Transform is called to translate the key to its prefix and
+    /// that returned prefix is inserted into the bloom filter. If this
+    /// method returns false, then the call to Transform is skipped and
+    /// no prefix is inserted into the bloom filters.
+    ///
+    /// For example, if the Transform method operates on a fixed length
+    /// prefix of size 4, then an invocation to InDomain("abc") returns
+    /// false because the specified key length(3) is shorter than the
+    /// prefix size of 4.
+    ///
+    /// Wiki documentation here:
+    /// https://github.com/facebook/rocksdb/wiki/Prefix-Seek-API-Changes
+    fn in_domain(&self, key: &[u8]) -> bool;
+
+    /// Some SliceTransform will have a full length which can be used to
+    /// determine if two keys are consecuitive. Can be disabled by always
+    /// returning 0
+    #[inline]
+    fn full_length_enabled(&self, _len: &mut usize) -> bool {
+        false
+    }
+
+    /// Transform(s)=Transform(`prefix`) for any s with `prefix` as a prefix.
+    ///
+    /// This function is not used by RocksDB, but for users. If users pass
+    /// Options by string to RocksDB, they might not know what prefix extractor
+    /// they are using. This function is to help users can determine:
+    ///   if they want to iterate all keys prefixing `prefix`, whether it is
+    ///   safe to use prefix bloom filter and seek to key `prefix`.
+    /// If this function returns true, this means a user can Seek() to a prefix
+    /// using the bloom filter. Otherwise, user needs to skip the bloom filter
+    /// by setting ReadOptions.total_order_seek = true.
+    ///
+    /// Here is an example: Suppose we implement a slice transform that returns
+    /// the first part of the string after splitting it using delimiter ",":
+    /// 1. SameResultWhenAppended("abc,") should return true. If applying prefix
+    ///    bloom filter using it, all slices matching "abc:.*" will be extracted
+    ///    to "abc,", so any SST file or memtable containing any of those key
+    ///    will not be filtered out.
+    /// 2. SameResultWhenAppended("abc") should return false. A user will not
+    ///    guaranteed to see all the keys matching "abc.*" if a user seek to "abc"
+    ///    against a DB with the same setting. If one SST file only contains
+    ///    "abcd,e", the file can be filtered out and the key will be invisible.
+    ///
+    /// i.e., an implementation always returning false is safe.
+    #[inline]
+    fn same_result_when_appended(&self, _prefix: &[u8]) -> bool {
+        false
+    }
+}
+
+extern "C" fn name<T: SliceTransform>(transform: *mut c_void) -> *const c_char {
+    unsafe {
+        let trans = &*(transform as *mut T);
+        trans.name().as_ptr()
+    }
+}
+
+extern "C" fn destructor<T: SliceTransform>(transform: *mut c_void) {
+    unsafe {
+        drop(Box::from_raw(transform as *mut T));
+    }
+}
+
+extern "C" fn transform<T: SliceTransform>(
+    transform: *mut c_void,
+    key: rocksdb_Slice,
+    dest: *mut rocksdb_Slice,
+) {
+    unsafe {
+        let trans = &*(transform as *mut T);
+        *dest = r(trans.transform(s(key)));
+    }
+}
+
+extern "C" fn in_domain<T: SliceTransform>(transform: *mut c_void, key: rocksdb_Slice) -> bool {
+    unsafe {
+        let trans = &*(transform as *mut T);
+        trans.in_domain(s(key))
+    }
+}
+
+extern "C" fn full_length_enabled<T: SliceTransform>(
+    transform: *mut c_void,
+    len: *mut usize,
+) -> bool {
+    unsafe {
+        let trans = &*(transform as *mut T);
+        trans.full_length_enabled(&mut *len)
+    }
+}
+
+extern "C" fn same_result_when_appended<T: SliceTransform>(
+    transform: *mut c_void,
+    key: rocksdb_Slice,
+) -> bool {
+    unsafe {
+        let trans = &*(transform as *mut T);
+        trans.same_result_when_appended(s(key))
+    }
+}
+
+/// A wrapped factory that can be shared by multiple ColumnFamilies and DBs.
+#[derive(Debug)]
+pub struct SysSliceTransform {
+    ptr: *mut crocksdb_slicetransform_t,
+}
+
+impl SysSliceTransform {
+    #[inline]
+    pub fn new<T: SliceTransform>(t: T) -> SysSliceTransform {
+        let ptr = unsafe {
+            tirocks_sys::crocksdb_slicetransform_create(
+                Box::into_raw(Box::new(t)) as *mut c_void,
+                Some(destructor::<T>),
+                Some(transform::<T>),
+                Some(in_domain::<T>),
+                Some(full_length_enabled::<T>),
+                Some(same_result_when_appended::<T>),
+                Some(name::<T>),
+            )
+        };
+        SysSliceTransform { ptr }
+    }
+
+    #[inline]
+    pub(crate) fn get_ptr(&self) -> *mut crocksdb_slicetransform_t {
+        self.ptr
+    }
+}
+
+impl Drop for SysSliceTransform {
+    #[inline]
+    fn drop(&mut self) {
+        unsafe { tirocks_sys::crocksdb_slicetransform_destroy(self.ptr) }
+    }
+}

--- a/tirocks/src/sst_partitioner.rs
+++ b/tirocks/src/sst_partitioner.rs
@@ -1,0 +1,182 @@
+// Copyright 2022 TiKV Project Authors. Licensed under Apache-2.0.
+
+use std::ffi::CStr;
+
+use libc::{c_char, c_void};
+use tirocks_sys::{
+    crocksdb_sst_partitioner_factory_t, rocksdb_PartitionerRequest, rocksdb_PartitionerResult,
+    rocksdb_Slice, rocksdb_SstPartitioner, rocksdb_SstPartitioner_Context, s,
+};
+
+pub type PartitionerResult = tirocks_sys::rocksdb_PartitionerResult;
+
+#[repr(transparent)]
+pub struct PartitionerRequest(rocksdb_PartitionerRequest);
+
+impl PartitionerRequest {
+    #[inline]
+    pub fn prev_user_key(&self) -> &[u8] {
+        unsafe { s(*self.0.prev_user_key) }
+    }
+
+    #[inline]
+    pub fn current_user_key(&self) -> &[u8] {
+        unsafe { s(*self.0.current_user_key) }
+    }
+
+    #[inline]
+    pub fn current_output_file_size(&self) -> u64 {
+        self.0.current_output_file_size
+    }
+}
+
+/// A SstPartitioner is a generic pluggable way of defining the partition
+/// of SST files. Compaction job will split the SST files on partition boundary
+/// to lower the write amplification during SST file promote to higher level.
+pub trait SstPartitioner: Send {
+    /// It is called for all keys in compaction. When partitioner want to create
+    /// new SST file it needs to return true. It means compaction job will finish
+    /// current SST file where last key is "prev_user_key" parameter and start new
+    /// SST file where first key is "current_user_key". Returns decission if
+    /// partition boundary was detected and compaction should create new file.
+    fn should_partition(&mut self, req: &PartitionerRequest) -> PartitionerResult;
+
+    /// Called with smallest and largest keys in SST file when compation try to do
+    /// trivial move. Returns true is partitioner allows to do trivial move.
+    fn can_do_trivial_move(&mut self, smallest_user_key: &[u8], largest_user_key: &[u8]) -> bool;
+}
+
+extern "C" fn destructor<P: SstPartitioner>(c: *mut c_void) {
+    unsafe {
+        drop(Box::from_raw(c as *mut P));
+    }
+}
+
+extern "C" fn should_partition<P: SstPartitioner>(
+    c: *mut c_void,
+    request: *const rocksdb_PartitionerRequest,
+) -> rocksdb_PartitionerResult {
+    unsafe {
+        let c = &mut *(c as *mut P);
+        c.should_partition(&*(request as *const PartitionerRequest))
+    }
+}
+
+extern "C" fn can_do_trivial_move<P: SstPartitioner>(
+    c: *mut c_void,
+    smallest_user_key: rocksdb_Slice,
+    largest_user_key: rocksdb_Slice,
+) -> bool {
+    unsafe {
+        let c = &mut *(c as *mut P);
+        c.can_do_trivial_move(s(smallest_user_key), s(largest_user_key))
+    }
+}
+
+#[repr(transparent)]
+pub struct Context(rocksdb_SstPartitioner_Context);
+
+impl Context {
+    /// Does this compaction run include all data files
+    #[inline]
+    pub fn is_full_compaction(&self) -> bool {
+        self.0.is_full_compaction
+    }
+
+    /// Is this compaction requested by the client (true),
+    /// or is it occurring as an automatic compaction process
+    #[inline]
+    pub fn is_manual_compaction(&self) -> bool {
+        self.0.is_manual_compaction
+    }
+
+    /// Output level for this compaction
+    #[inline]
+    pub fn output_level(&self) -> i32 {
+        self.0.output_level
+    }
+
+    /// Smallest key for compaction
+    #[inline]
+    pub fn smallest_user_key(&self) -> &[u8] {
+        unsafe { s(self.0.smallest_user_key) }
+    }
+
+    /// Largest key for compaction
+    #[inline]
+    pub fn largest_user_key(&self) -> &[u8] {
+        unsafe { s(self.0.largest_user_key) }
+    }
+}
+
+pub trait SstPartitionerFactory: Send + Sync {
+    type Partitioner: SstPartitioner;
+
+    /// Returns a name that identifies this partitioner factory.
+    fn name(&self) -> &CStr;
+
+    fn create_partitioner(&self, context: &Context) -> Self::Partitioner;
+}
+
+extern "C" fn factory_name<T: SstPartitionerFactory>(factory: *mut c_void) -> *const c_char {
+    unsafe {
+        let factory = &mut *(factory as *mut T);
+        factory.name().as_ptr()
+    }
+}
+
+extern "C" fn factory_destruct<T: SstPartitionerFactory>(handle: *mut c_void) {
+    unsafe {
+        Box::from_raw(handle as *mut T);
+    }
+}
+
+extern "C" fn create_partitioner<T: SstPartitionerFactory>(
+    handle: *mut c_void,
+    context: *const rocksdb_SstPartitioner_Context,
+) -> *mut rocksdb_SstPartitioner {
+    unsafe {
+        let handle = &*(handle as *mut T);
+        let context = &*(context as *const Context);
+        let p = handle.create_partitioner(context);
+        tirocks_sys::crocksdb_sst_partitioner_create(
+            Box::into_raw(Box::new(p)) as *mut c_void,
+            Some(destructor::<T::Partitioner>),
+            Some(should_partition::<T::Partitioner>),
+            Some(can_do_trivial_move::<T::Partitioner>),
+        )
+    }
+}
+
+/// A wrapped factory that can be shared by multiple ColumnFamilies and DBs.
+#[derive(Debug)]
+pub struct SysSstParitionerFactory {
+    ptr: *mut crocksdb_sst_partitioner_factory_t,
+}
+
+impl SysSstParitionerFactory {
+    #[inline]
+    pub fn new<T: SstPartitionerFactory>(factory: T) -> SysSstParitionerFactory {
+        let ptr = unsafe {
+            tirocks_sys::crocksdb_sst_partitioner_factory_create(
+                Box::into_raw(Box::new(factory)) as *mut c_void,
+                Some(factory_destruct::<T>),
+                Some(factory_name::<T>),
+                Some(create_partitioner::<T>),
+            )
+        };
+        SysSstParitionerFactory { ptr }
+    }
+
+    #[inline]
+    pub(crate) fn get_ptr(&self) -> *mut crocksdb_sst_partitioner_factory_t {
+        self.ptr
+    }
+}
+
+impl Drop for SysSstParitionerFactory {
+    #[inline]
+    fn drop(&mut self) {
+        unsafe { tirocks_sys::crocksdb_sst_partitioner_factory_destroy(self.ptr) }
+    }
+}

--- a/tirocks/src/util.rs
+++ b/tirocks/src/util.rs
@@ -120,6 +120,19 @@ macro_rules! simple_access {
 
 pub(crate) use simple_access;
 
+/// A helper macro to convert status to Result.
+macro_rules! check_status {
+    ($status:ident) => {
+        if $status.ok() {
+            Ok(())
+        } else {
+            Err($status)
+        }
+    };
+}
+
+pub(crate) use check_status;
+
 // `FnOnce` is a more accurate type, but it will require Unpin.
 unsafe extern "C" fn bytes_receiver<T: FnMut(&[u8])>(ptr: *mut c_void, buf: rocksdb_Slice) {
     (*(ptr as *mut T))(s(buf))
@@ -129,4 +142,95 @@ pub type BytesReceiver = unsafe extern "C" fn(*mut c_void, rocksdb_Slice);
 
 pub fn wrap_string_receiver<T: FnMut(&[u8])>(receiver: &mut T) -> (*mut c_void, BytesReceiver) {
     (receiver as *mut T as *mut c_void, bytes_receiver::<T>)
+}
+
+/// A common factory for all types that creates types using `Default` trait.
+pub struct DefaultFactory<F> {
+    item: PhantomData<F>,
+}
+
+impl<F> DefaultFactory<F> {
+    #[inline]
+    pub(crate) fn c_name(&self) -> &CStr {
+        CStr::from_bytes_with_nul(b"DefaultFactory\0").unwrap()
+    }
+}
+
+impl<F> Default for DefaultFactory<F> {
+    #[inline]
+    fn default() -> Self {
+        Self { item: PhantomData }
+    }
+}
+
+unsafe impl<F> Send for DefaultFactory<F> {}
+unsafe impl<F> Sync for DefaultFactory<F> {}
+
+/// A common factory for items that can be cloned.
+pub struct CloneFactory<F> {
+    item: F,
+}
+
+impl<F> CloneFactory<F> {
+    #[inline]
+    pub fn new(item: F) -> Self {
+        CloneFactory { item }
+    }
+
+    #[inline]
+    pub(crate) fn c_name(&self) -> &CStr {
+        CStr::from_bytes_with_nul(b"CloneFactory\0").unwrap()
+    }
+
+    #[inline]
+    pub(crate) fn name(&self) -> &str {
+        "CloneFactory"
+    }
+}
+
+impl<F: Clone> CloneFactory<F> {
+    pub(crate) fn clone(&self) -> F {
+        self.item.clone()
+    }
+}
+
+#[inline]
+pub unsafe fn rocks_slice_to_array(arr: &[rocksdb_Slice]) -> Cow<[&[u8]]> {
+    if tirocks_sys::rocks_slice_same_as_rust() {
+        Cow::Borrowed(mem::transmute(arr))
+    } else {
+        let arr = arr.into_iter().map(|v| unsafe { s(*v) }).collect();
+        Cow::Owned(arr)
+    }
+}
+
+#[inline]
+pub unsafe fn array_to_rocks_slice<'a>(arr: &'a [&[u8]]) -> Cow<'a, [rocksdb_Slice]> {
+    if tirocks_sys::rocks_slice_same_as_rust() {
+        Cow::Borrowed(mem::transmute(arr))
+    } else {
+        let arr = arr.into_iter().map(|v| unsafe { r(*v) }).collect();
+        Cow::Owned(arr)
+    }
+}
+
+pub unsafe fn range_to_range_ptr(
+    ranges: &[(Option<&[u8]>, Option<&[u8]>)],
+) -> (
+    Vec<(Option<rocksdb_Slice>, Option<rocksdb_Slice>)>,
+    Vec<rocksdb_RangePtr>,
+) {
+    let rocks_ranges: Vec<_> = ranges
+        .iter()
+        .map(|pair| (pair.0.map(|k| r(k)), pair.1.map(|k| r(k))))
+        .collect();
+    // It may be optimized by `rocks_slice_same_as_rust`, but it seems too risky.
+    let range_ptrs: Vec<_> = rocks_ranges
+        .iter()
+        .map(|(begin, end)| rocksdb_RangePtr {
+            start: begin.as_ref().map_or_else(ptr::null, |k| k),
+            limit: end.as_ref().map_or_else(ptr::null, |k| k),
+        })
+        .collect();
+    (rocks_ranges, range_ptrs)
 }

--- a/tirocks/src/util.rs
+++ b/tirocks/src/util.rs
@@ -199,7 +199,7 @@ pub unsafe fn rocks_slice_to_array(arr: &[rocksdb_Slice]) -> Cow<[&[u8]]> {
     if tirocks_sys::rocks_slice_same_as_rust() {
         Cow::Borrowed(mem::transmute(arr))
     } else {
-        let arr = arr.into_iter().map(|v| unsafe { s(*v) }).collect();
+        let arr = arr.iter().map(|v| unsafe { s(*v) }).collect();
         Cow::Owned(arr)
     }
 }
@@ -209,17 +209,15 @@ pub unsafe fn array_to_rocks_slice<'a>(arr: &'a [&[u8]]) -> Cow<'a, [rocksdb_Sli
     if tirocks_sys::rocks_slice_same_as_rust() {
         Cow::Borrowed(mem::transmute(arr))
     } else {
-        let arr = arr.into_iter().map(|v| unsafe { r(*v) }).collect();
+        let arr = arr.iter().map(|v| unsafe { r(*v) }).collect();
         Cow::Owned(arr)
     }
 }
 
-pub unsafe fn range_to_range_ptr(
-    ranges: &[(Option<&[u8]>, Option<&[u8]>)],
-) -> (
-    Vec<(Option<rocksdb_Slice>, Option<rocksdb_Slice>)>,
-    Vec<rocksdb_RangePtr>,
-) {
+pub type RustRange<'a> = (Option<&'a [u8]>, Option<&'a [u8]>);
+pub type RocksRange = (Option<rocksdb_Slice>, Option<rocksdb_Slice>);
+
+pub unsafe fn range_to_range_ptr(ranges: &[RustRange]) -> (Vec<RocksRange>, Vec<rocksdb_RangePtr>) {
     let rocks_ranges: Vec<_> = ranges
         .iter()
         .map(|pair| (pair.0.map(|k| r(k)), pair.1.map(|k| r(k))))


### PR DESCRIPTION
This PR adds compaction filter, mem table, merge operator, slice transform and sst partitioner that required by cf options.

Compared to rust-rocksdb, more details of APIs are exposed. And every share-able c++ type are wrapped with `SysXxx`, so that they can be shared between rocksdbs in the future.